### PR TITLE
Remove test and prod deployments from the main Jenkins pipeline.

### DIFF
--- a/tob-web/Jenkinsfile
+++ b/tob-web/Jenkinsfile
@@ -27,16 +27,16 @@ node {
   }
 }
 
-node {
-  stage('deploy-' + TAG_NAMES[1]) {
-    input "Deploy to " + TAG_NAMES[1] + "?"
-    openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[1], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
-  }
-}
+// node {
+  // stage('deploy-' + TAG_NAMES[1]) {
+    // input "Deploy to " + TAG_NAMES[1] + "?"
+    // openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[1], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
+  // }
+// }
 
-node {
-  stage('deploy-'  + TAG_NAMES[2]) {
-    input "Deploy to " + TAG_NAMES[2] + "?"
-    openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[2], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
-  }
-}
+// node {
+  // stage('deploy-'  + TAG_NAMES[2]) {
+    // input "Deploy to " + TAG_NAMES[2] + "?"
+    // openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[2], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
+  // }
+// }


### PR DESCRIPTION
The test and prod deployments require input for the build to complete.  When you don't proceed with the deployments to test and prod the build shows as canceled, which is misleading when all you wanted to do was to deploy a successful build to dev and not to test or prod.

Deployment to test and prod are a separate concern.