### PR TITLE
Re-deploy schema-spy when the API changes.

### DIFF
--- a/tob-api/Jenkinsfile
+++ b/tob-api/Jenkinsfile
@@ -7,6 +7,7 @@ def TAG_NAMES = ['dev', 'test', 'prod']
 // You shouldn't have to edit these if you're following the conventions
 def BUILD_CONFIG = APP_NAME
 def IMAGESTREAM_NAME = APP_NAME
+def SCHEMA_SPY_IMAGSTREAM_NAME = 'schema-spy'
 
 node {
 
@@ -18,5 +19,6 @@ node {
   
   stage('deploy-' + TAG_NAMES[0]) {
     openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
+    openshiftTag destStream: SCHEMA_SPY_IMAGSTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: SCHEMA_SPY_IMAGSTREAM_NAME, srcTag: 'latest'
   }
 }


### PR DESCRIPTION
Re-deploy schema-spy when the API changes so an related schema changes will be picked up.