### PR TITLE
Update pipeline build process

### DIFF
--- a/openshift/initializeProjects.sh
+++ b/openshift/initializeProjects.sh
@@ -56,6 +56,10 @@ TOOLS_PROJECT="${PROJECT_NAMESPACE}-${TOOLS_PROJECT_NAME}"
 DEV_PROJECT="${PROJECT_NAMESPACE}-${DEV_PROJECT_NAME}"
 TEST_PROJECT="${PROJECT_NAMESPACE}-${TEST_PROJECT_NAME}"
 PROD_PROJECT="${PROJECT_NAMESPACE}-${PROD_PROJECT_NAME}"
+
+JENKINS_ACCOUNT_NAME="jenkins"
+JENKINS_SERVICE_ACCOUNT_NAME="system:serviceaccount:${TOOLS_PROJECT}:${JENKINS_ACCOUNT_NAME}"
+JENKINS_SERVICE_ACCOUNT_ROLE="edit"
 # ===================================================================================
 
 echo "============================================================================="
@@ -72,6 +76,31 @@ ${SCRIPTS_DIR}/grantDeploymentPrivileges.sh \
 ${SCRIPTS_DIR}/grantDeploymentPrivileges.sh \
 	${PROD_PROJECT} \
 	${TOOLS_PROJECT}
+
+${SCRIPTS_DIR}/grantDeploymentPrivileges.sh \
+	${PROD_PROJECT} \
+	${TOOLS_PROJECT}
+	
+echo "============================================================================"
+echo
+
+echo "============================================================================="
+echo "Initializing permissions for the Jenkins service account ..."
+echo "-----------------------------------------------------------------------------"
+${SCRIPTS_DIR}/updatePolicy.sh \
+	${JENKINS_SERVICE_ACCOUNT_ROLE} \
+	${JENKINS_SERVICE_ACCOUNT_NAME} \
+	${DEV_PROJECT}
+
+${SCRIPTS_DIR}/updatePolicy.sh \
+	${JENKINS_SERVICE_ACCOUNT_ROLE} \
+	${JENKINS_SERVICE_ACCOUNT_NAME} \
+	${TEST_PROJECT}
+
+${SCRIPTS_DIR}/updatePolicy.sh \
+	${JENKINS_SERVICE_ACCOUNT_ROLE} \
+	${JENKINS_SERVICE_ACCOUNT_NAME} \
+	${PROD_PROJECT}
 
 echo "============================================================================"
 echo

--- a/openshift/scripts/updatePolicy.sh
+++ b/openshift/scripts/updatePolicy.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+SCRIPT_DIR=$(dirname $0)
+
+# ===================================================================================================
+# Funtions
+# ---------------------------------------------------------------------------------------------------
+usage (){
+  echo "========================================================================================"
+  echo "Updates the permissions (policy bindings) on an OpenShift project set."
+  echo
+  echo "----------------------------------------------------------------------------------------"
+  echo "Usage:"
+  echo
+  echo "${0} <role> <user> <project_namespace>"
+  echo
+  echo "Where:"
+  echo " - <role> is the role to grant to the user; edit, admin, etc."
+  echo " - <user> is GitHub userId of the user who will be granted the permissions."
+  echo " - <project_namespace> the root namespace for the project set."
+  echo
+  echo "Examples:"
+  echo "${0} edit mrDeveloper devex-von"
+  echo "========================================================================================"
+  exit 1
+}
+
+exitOnError (){
+  rtnCd=$?
+  if [ ${rtnCd} -ne 0 ]; then
+	echo "An error has occurred.!  Please check the previous output message(s) for details."
+    exit ${rtnCd}
+  fi
+}
+
+assignRole (){
+  role=$1
+  user=$2
+  project=$3
+  
+  echo "Assigning role [${role}], to user [${user}], in project [${project}] ..."
+  oc policy add-role-to-user ${role} ${user} -n ${project}
+
+  echo
+  echo "Resulting policy bindings for project; [$project] ..."
+  oc describe policyBindings --namespace=${project}
+
+  echo
+  echo
+}
+
+projectExists (){
+  project=$1
+  rtnVal=$(oc projects | grep ${project})
+  if [ -z "$rtnVal" ]; then
+    # Project does not exist ..."
+	return 1
+  else
+    # Project exists ..."
+	return 0
+  fi
+}
+# ===================================================================================================
+
+# ===================================================================================================
+# Setup
+# ---------------------------------------------------------------------------------------------------
+if [ -z "${1}" ]; then
+  usage  
+elif [ -z "${2}" ]; then
+  usage  
+elif [ -z "${3}" ]; then
+  usage
+elif [ ! -z "${4}" ]; then
+  usage  
+else
+  ROLE=$1
+  USERNAME=$2
+  PROJECT_NAMESPACE=$3
+fi
+
+if [ -z "$TOOLS_PROJECT_NAME" ]; then
+	TOOLS_PROJECT_NAME="tools"
+fi
+
+if [ -z "$DEV_PROJECT_NAME" ]; then
+	DEV_PROJECT_NAME="dev"
+fi
+
+if [ -z "$TEST_PROJECT_NAME" ]; then
+	TEST_PROJECT_NAME="test"
+fi
+
+if [ -z "$PROD_PROJECT_NAME" ]; then
+	PROD_PROJECT_NAME="prod"
+fi
+# ---------------------------------------------------------------------------------------------------
+TOOLS_PROJECT="${PROJECT_NAMESPACE}-${TOOLS_PROJECT_NAME}"
+DEV_PROJECT="${PROJECT_NAMESPACE}-${DEV_PROJECT_NAME}"
+TEST_PROJECT="${PROJECT_NAMESPACE}-${TEST_PROJECT_NAME}"
+PROD_PROJECT="${PROJECT_NAMESPACE}-${PROD_PROJECT_NAME}"
+# ===================================================================================================
+
+if projectExists ${TOOLS_PROJECT}; then
+  assignRole ${ROLE} ${USERNAME} ${TOOLS_PROJECT}
+fi
+ 
+if projectExists ${DEV_PROJECT}; then
+  assignRole ${ROLE} ${USERNAME} ${DEV_PROJECT}
+fi
+
+if projectExists ${TEST_PROJECT}; then
+  assignRole ${ROLE} ${USERNAME} ${TEST_PROJECT}
+fi
+
+if projectExists ${PROD_PROJECT}; then
+  assignRole ${ROLE} ${USERNAME} ${PROD_PROJECT}
+fi

--- a/tob-api/Jenkinsfile
+++ b/tob-api/Jenkinsfile
@@ -9,22 +9,66 @@ def BUILD_CONFIG = APP_NAME
 def IMAGESTREAM_NAME = APP_NAME
 def SCHEMA_SPY_IMAGSTREAM_NAME = 'schema-spy'
 def PROJECT_NAMESPACE = 'devex-von-'
+def CONTEXT_DIRECTORY = 'tob-api'
 
-node {
-
-  stage('build ' + BUILD_CONFIG) {
-    echo "Building: " + BUILD_CONFIG
-    openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
-    openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: '$BUILD_ID', srcStream: IMAGESTREAM_NAME, srcTag: 'latest'
+@NonCPS
+boolean triggerBuild(String contextDirectory) {
+  // Determine if code has changed within the source context directory.
+  def changeLogSets = currentBuild.changeSets
+  def filesChangeCnt = 0
+  for (int i = 0; i < changeLogSets.size(); i++) {
+    def entries = changeLogSets[i].items
+    for (int j = 0; j < entries.length; j++) {
+      def entry = entries[j]
+      //echo "${entry.commitId} by ${entry.author} on ${new Date(entry.timestamp)}: ${entry.msg}"
+      def files = new ArrayList(entry.affectedFiles)
+      for (int k = 0; k < files.size(); k++) {
+        def file = files[k]
+        def filePath = file.path
+        //echo ">> ${file.path}"
+        if (filePath.contains(contextDirectory)) {
+          filesChangeCnt = 1
+          k = files.size()
+          j = entries.length
+        }
+      }
+    }
   }
   
-  stage('deploy-' + TAG_NAMES[0]) {
-    openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
-    openshiftTag destStream: SCHEMA_SPY_IMAGSTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: SCHEMA_SPY_IMAGSTREAM_NAME, srcTag: 'latest'
+  if ( filesChangeCnt < 1 ) {
+    echo('The changes do not require a build.')
+    return false
   }
+  else {
+    echo('The changes require a build.')
+    return true
+  } 
+}
 
-  stage('Update ' + SCHEMA_SPY_IMAGSTREAM_NAME + ' instance in ' + TAG_NAMES[0]) {
-	openshiftScale deploymentConfig: SCHEMA_SPY_IMAGSTREAM_NAME, replicaCount: 0, namespace: PROJECT_NAMESPACE + TAG_NAMES[0]
-	openshiftScale deploymentConfig: SCHEMA_SPY_IMAGSTREAM_NAME, replicaCount: 1, namespace: PROJECT_NAMESPACE + TAG_NAMES[0]
+node {
+  if( triggerBuild(CONTEXT_DIRECTORY) ) {
+    stage('build ' + BUILD_CONFIG) {
+      echo "Building: " + BUILD_CONFIG
+      openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
+      openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: '$BUILD_ID', srcStream: IMAGESTREAM_NAME, srcTag: 'latest'
+    }
+
+    stage('deploy-' + TAG_NAMES[0]) {
+      openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
+      openshiftTag destStream: SCHEMA_SPY_IMAGSTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: SCHEMA_SPY_IMAGSTREAM_NAME, srcTag: 'latest'
+    }
+
+    // For this to work the Jenkins service mush have edit permissions within the deployment project.
+    // Example OC cmd to accomplish this task (it's better if you have projet init scripts that do this);
+    // oc policy add-role-to-user edit system:serviceaccount:devex-von-tools:jenkins -n devex-von-dev
+    stage('Update ' + SCHEMA_SPY_IMAGSTREAM_NAME + ' instance in ' + TAG_NAMES[0]) {
+      openshiftScale deploymentConfig: SCHEMA_SPY_IMAGSTREAM_NAME, replicaCount: 0, namespace: PROJECT_NAMESPACE + TAG_NAMES[0]
+      openshiftScale deploymentConfig: SCHEMA_SPY_IMAGSTREAM_NAME, replicaCount: 1, namespace: PROJECT_NAMESPACE + TAG_NAMES[0]
+    }
+  }
+  else {
+    stage('No Changes') {
+      currentBuild.result = 'SUCCESS'
+    }
   }
 }

--- a/tob-web/Jenkinsfile
+++ b/tob-web/Jenkinsfile
@@ -8,23 +8,64 @@ def TAG_NAMES = ['dev', 'test', 'prod']
 def NGINX_BUILD_CONFIG = 'nginx-runtime'
 def BUILD_CONFIG = APP_NAME + '-build'
 def IMAGESTREAM_NAME = APP_NAME
+def CONTEXT_DIRECTORY = 'tob-web'
+
+@NonCPS
+boolean triggerBuild(String contextDirectory) {
+  // Determine if code has changed within the source context directory.
+  def changeLogSets = currentBuild.changeSets
+  def filesChangeCnt = 0
+  for (int i = 0; i < changeLogSets.size(); i++) {
+    def entries = changeLogSets[i].items
+    for (int j = 0; j < entries.length; j++) {
+      def entry = entries[j]
+      //echo "${entry.commitId} by ${entry.author} on ${new Date(entry.timestamp)}: ${entry.msg}"
+      def files = new ArrayList(entry.affectedFiles)
+      for (int k = 0; k < files.size(); k++) {
+        def file = files[k]
+        def filePath = file.path
+        //echo ">> ${file.path}"
+        if (filePath.contains(contextDirectory)) {
+          filesChangeCnt = 1
+          k = files.size()
+          j = entries.length
+        }
+      }
+    }
+  }
+  
+  if ( filesChangeCnt < 1 ) {
+    echo('The changes do not require a build.')
+    return false
+  }
+  else {
+    echo('The changes require a build.')
+    return true
+  } 
+}
 
 node {
-
-  stage('build nginx runtime') {
-    echo "Building: " + NGINX_BUILD_CONFIG
-    openshiftBuild bldCfg: NGINX_BUILD_CONFIG, showBuildLogs: 'true'
-    openshiftTag destStream: NGINX_BUILD_CONFIG, verbose: 'true', destTag: '$BUILD_ID', srcStream: NGINX_BUILD_CONFIG, srcTag: 'latest'
+  if( triggerBuild(CONTEXT_DIRECTORY) ) {
+    stage('build nginx runtime') {
+      echo "Building: " + NGINX_BUILD_CONFIG
+      openshiftBuild bldCfg: NGINX_BUILD_CONFIG, showBuildLogs: 'true'
+      openshiftTag destStream: NGINX_BUILD_CONFIG, verbose: 'true', destTag: '$BUILD_ID', srcStream: NGINX_BUILD_CONFIG, srcTag: 'latest'
+    }
+    
+    stage('build ' + BUILD_CONFIG) {
+      echo "Building: " + BUILD_CONFIG
+      openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
+      openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: '$BUILD_ID', srcStream: IMAGESTREAM_NAME, srcTag: 'latest'
+    }
+    
+    stage('deploy-' + TAG_NAMES[0]) {
+      openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
+    }
   }
-  
-  stage('build ' + BUILD_CONFIG) {
-    echo "Building: " + BUILD_CONFIG
-    openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
-    openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: '$BUILD_ID', srcStream: IMAGESTREAM_NAME, srcTag: 'latest'
-  }
-  
-  stage('deploy-' + TAG_NAMES[0]) {
-    openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: '$BUILD_ID'
+  else {
+    stage('No Changes') {
+      currentBuild.result = 'SUCCESS'
+    }
   }
 }
 


### PR DESCRIPTION
First pass at eliminating unnecessary builds and deployments.

Unfortunately the code contained in a Jenkins file is unable to affect the Pipeline's top level SCM settings to take advantage of the include and exclude filters that would stop the builds from being triggered.

We've taken steps at the next available level to short-circuit the build and avoid building anything if there were no changes in the context directory for the pipeline.  A 'build' still gets kicked off, but we avoid re-building and deploying things unnecessarily.

Plus;
- Updates to code documentation.
- Update initializeProjects scrip to grant Jenkins service account access to scale deployments.