### PR TITLE
QuickLoad cleanup

### DIFF
--- a/tob-api/api/urls.py
+++ b/tob-api/api/urls.py
@@ -51,6 +51,9 @@ class SwaggerSchemaView(APIView):
 urlpatterns = [
     # Swagger documentation
     url(r'^$', SwaggerSchemaView.as_view()),
+
+    url(r'^quickload$', views_custom.QuickLoad.as_view()),
+
     url(r'^users/current$', views_custom.usersCurrentGet.as_view()),
 
     url(r'^doingbusinessas/bulk$', views.doingbusinessasBulkPost.as_view()),

--- a/tob-api/api/views_custom.py
+++ b/tob-api/api/views_custom.py
@@ -20,6 +20,7 @@
 """
 
 from rest_framework.views import APIView
+from django.http.response import JsonResponse
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework import permissions 
@@ -148,3 +149,35 @@ class verifiableOrgsIdLocationsGet(APIView):
     locations = Location.objects.filter(verifiableOrgId=org)
     serializer = serializers.LocationSerializer(locations, many=True)
     return Response(serializer.data)
+
+class QuickLoad(APIView):
+  def get(self, request):
+    """
+    Used to initialize a client application.
+    Returns record counts, and data types required by the web application to perform filtering and/or populate list(s).
+    """
+    response = {'counts': {}, 'records': {}}
+
+    countOrgs = VerifiableOrg.objects.count()
+    countClaims = VerifiableClaim.objects.count()
+    response['counts'] = {'verifiableorgs': countOrgs, 'verifiableclaims': countClaims}
+
+    inactive = InactiveClaimReason.objects.all()
+    response['records']['inactiveclaimreasons'] = serializers.InactiveClaimReasonSerializer(inactive, many=True).data
+
+    issuers = IssuerService.objects.all()
+    response['records']['issuerservices'] = serializers.IssuerServiceSerializer(issuers, many=True).data
+
+    jurisd = Jurisdiction.objects.all()
+    response['records']['jurisdictions'] = serializers.JurisdictionSerializer(jurisd, many=True).data
+
+    locTypes = LocationType.objects.all()
+    response['records']['locationtypes'] = serializers.LocationTypeSerializer(locTypes, many=True).data
+
+    claimTypes = VerifiableClaimType.objects.all()
+    response['records']['verifiableclaimtypes'] = serializers.VerifiableClaimTypeSerializer(claimTypes, many=True).data
+
+    orgTypes = VerifiableOrgType.objects.all()
+    response['records']['verifiableorgtypes'] = serializers.VerifiableOrgTypeSerializer(orgTypes, many=True).data
+
+    return JsonResponse(response)

--- a/tob-api/tob_api/urls.py
+++ b/tob-api/tob_api/urls.py
@@ -12,7 +12,6 @@ from . import views
 
 urlpatterns = [
     url(r'^$', RedirectView.as_view(url='api/v1/')),
-    url(r'^api/v1/quickload', views.quickload),
     url(r'^api/v1/', include('api.urls')),
     url(r'^health$', views.health),
 ]

--- a/tob-api/tob_api/views.py
+++ b/tob-api/tob_api/views.py
@@ -19,35 +19,3 @@ def health(request):
     Health check for OpenShift
     """
     return HttpResponse(VerifiableClaim.objects.count())
-
-
-def quickload(request):
-	"""
-	Return record counts and data types required by the web application, all together
-	"""
-
-	response = {'counts': {}, 'records': {}}
-
-	countOrgs = VerifiableOrg.objects.count()
-	countClaims = VerifiableClaim.objects.count()
-	response['counts'] = {'verifiableorgs': countOrgs, 'verifiableclaims': countClaims}
-
-	inactive = InactiveClaimReason.objects.all()
-	response['records']['inactiveclaimreasons'] = serializers.InactiveClaimReasonSerializer(inactive, many=True).data
-
-	issuers = IssuerService.objects.all()
-	response['records']['issuerservices'] = serializers.IssuerServiceSerializer(issuers, many=True).data
-
-	jurisd = Jurisdiction.objects.all()
-	response['records']['jurisdictions'] = serializers.JurisdictionSerializer(jurisd, many=True).data
-
-	locTypes = LocationType.objects.all()
-	response['records']['locationtypes'] = serializers.LocationTypeSerializer(locTypes, many=True).data
-
-	claimTypes = VerifiableClaimType.objects.all()
-	response['records']['verifiableclaimtypes'] = serializers.VerifiableClaimTypeSerializer(claimTypes, many=True).data
-
-	orgTypes = VerifiableOrgType.objects.all()
-	response['records']['verifiableorgtypes'] = serializers.VerifiableOrgTypeSerializer(orgTypes, many=True).data
-
-	return JsonResponse(response)


### PR DESCRIPTION
- moved the view and url into the api; route remains the same.
- refactored into a class to take advantage of the auto-generated api documentation.