### PR TITLE
Groups search results by type.

### DIFF
--- a/tob-api/api/search_serializers.py
+++ b/tob-api/api/search_serializers.py
@@ -1,10 +1,14 @@
 from drf_haystack.serializers import HaystackSerializerMixin, HaystackSerializer
+from django.db.models.manager import Manager
+from rest_framework.serializers import ListSerializer
 from api.search_indexes import LocationIndex
 from api.search_indexes import DoingBusinessAsIndex
 from api.search_indexes import VerifiableOrgIndex
 from api.serializers import DoingBusinessAsSerializer
 from api.serializers import VerifiableOrgSerializer
 from api.serializers import LocationSerializer
+from collections import OrderedDict
+from rest_framework.utils.serializer_helpers import ReturnDict
 
 # -----------------------------------------------------------------------------------
 # The Search serializers reuse the model serializers as shown here;
@@ -32,8 +36,33 @@ class LocationSearchSerializer(HaystackSerializerMixin, LocationSerializer):
     field_aliases = {}
     exclude = tuple()
 
+class SearchResultsListSerializer(ListSerializer):
+  @staticmethod
+  def __camelCase(s):
+    return s[:1].lower() + s[1:] if s else ''
+
+  def __get_keyName(self, instance):
+    searchIndex = instance.searchindex
+    model = searchIndex.get_model()
+    return self.__camelCase(model.__name__)
+  
+  @property
+  def data(self):
+    ret = super(ListSerializer, self).data
+    return ReturnDict(ret, serializer=self)  
+    
+  def to_representation(self, data):
+    results = OrderedDict()
+    iterable = data.all() if isinstance(data, Manager) else data
+    for item in iterable:
+      searchIndexName = self.__get_keyName(item)
+      results.setdefault(searchIndexName, []).append(self.child.to_representation(item))
+
+    return results
+
 class NameSearchSerializer(HaystackSerializer):
   class Meta:
+    list_serializer_class = SearchResultsListSerializer
     search_fields = ("name", )    
     field_aliases = {}
     exclude = tuple()
@@ -44,6 +73,7 @@ class NameSearchSerializer(HaystackSerializer):
 
 class OrganizationSearchSerializer(HaystackSerializer):
   class Meta:
+    list_serializer_class = SearchResultsListSerializer
     search_fields = ("text", )
     field_aliases = {}
     exclude = tuple()

--- a/tob-api/api/search_views.py
+++ b/tob-api/api/search_views.py
@@ -72,7 +72,7 @@ class NameSearchView(ListModelMixin, HaystackGenericAPIView):
         Searches across the 'name' fields of Verifiable Organization and 
         Doing Business As records.
         
-        Returns any records that match the search criteria.
+        Returns any records that match the search criteria.  The results are grouped by type.  The results are not guaranteed to always be returned in the same order.
 
         Search field:
         - name
@@ -82,26 +82,37 @@ class NameSearchView(ListModelMixin, HaystackGenericAPIView):
         .../api/v1/search/name?name=gas
         ```
 
-        Returns:
+        Returns results, such as:
         ```
-        [
-            {
-                "id": 8,
-                "busId": "74905418",
-                "orgTypeId": 1,
-                "jurisdictionId": 1,
-                "LegalName": "Gamma Gas",
-                "effectiveDate": "2010-10-10",
-                "endDate": null
-            },
-            {
-                "id": 18,
-                "verifiableOrgId": 8,
-                "DBA": "Gas Depot",
-                "effectiveDate": "2010-10-10",
-                "endDate": null
-            }
-        ]
+        {
+            "doingBusinessAs": [
+                {
+                    "id": 12,
+                    "verifiableOrgId": 14,
+                    "dbaName": "Gas Depot",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                },
+                {
+                    "id": 18,
+                    "verifiableOrgId": 14,
+                    "dbaName": "Gas Planet",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                }
+            ],
+            "verifiableOrg": [
+                {
+                    "id": 16,
+                    "orgId": "30042089",
+                    "orgTypeId": 1,
+                    "jurisdictionId": 1,
+                    "legalName": "Gamma Gas",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                }
+            ]
+        }
         ```
         """
         return self.list(request, *args, **kwargs)
@@ -113,7 +124,7 @@ class OrganizationSearchView(ListModelMixin, HaystackGenericAPIView):
         """
         Searches across the text fields of Verifiable Organization, Doing Business As, and Location records.
         
-        Returns any records that match the search criteria.
+        Returns any records that match the search criteria.  The results are grouped by type.  The results are not guaranteed to always be returned in the same order.
 
         Search field:
         - text
@@ -123,56 +134,71 @@ class OrganizationSearchView(ListModelMixin, HaystackGenericAPIView):
         .../api/v1/search/organization?text=gas
         ```
 
-        Returns:
+        Returns results, such as:
         ```
-        [
-            {
-                "id": 18,
-                "verifiableOrgId": 8,
-                "DBA": "Gas Depot",
-                "effectiveDate": "2010-10-10",
-                "endDate": null
-            },
-            {
-                "id": 24,
-                "verifiableOrgId": 8,
-                "locationTypeId": 2,
-                "addressee": "Gamma Gas",
-                "addlDeliveryInfo": null,
-                "unitNumber": null,
-                "streetAddress": "735 Wallace Street",
-                "municipality": "Nanaimo",
-                "province": "BC",
-                "postalCode": "V9R 3A8",
-                "latLong": "49.108632, -123.871502",
-                "effectiveDate": "2010-10-10",
-                "endDate": null
-            },
-            {
-                "id": 26,
-                "verifiableOrgId": 8,
-                "locationTypeId": 2,
-                "addressee": "Gas Depot",
-                "addlDeliveryInfo": null,
-                "unitNumber": null,
-                "streetAddress": "2890 Burdett Avenue",
-                "municipality": "Victoria",
-                "province": "BC",
-                "postalCode": "V8Y 1Y7",
-                "latLong": "48.415871, -123.392253",
-                "effectiveDate": "2010-10-10",
-                "endDate": null
-            },
-            {
-                "id": 8,
-                "busId": "74905418",
-                "orgTypeId": 1,
-                "jurisdictionId": 1,
-                "LegalName": "Gamma Gas",
-                "effectiveDate": "2010-10-10",
-                "endDate": null
-            }
-        ]
+        {
+            "location": [
+                {
+                    "id": 24,
+                    "verifiableOrgId": 14,
+                    "doingBusinessAsId": null,
+                    "locationTypeId": 1,
+                    "addressee": "Gamma Gas",
+                    "addlDeliveryInfo": null,
+                    "unitNumber": null,
+                    "streetAddress": "735 Wallace Street",
+                    "municipality": "Nanaimo",
+                    "province": "BC",
+                    "postalCode": "V9R 3A8",
+                    "latLong": "49.108632, -123.871502",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                },
+                {
+                    "id": 26,
+                    "verifiableOrgId": 14,
+                    "doingBusinessAsId": 12,
+                    "locationTypeId": 2,
+                    "addressee": "Gas Depot",
+                    "addlDeliveryInfo": null,
+                    "unitNumber": null,
+                    "streetAddress": "2890 Burdett Avenue",
+                    "municipality": "Victoria",
+                    "province": "BC",
+                    "postalCode": "V8Y 1Y7",
+                    "latLong": "48.415871, -123.392253",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                }
+            ],
+            "doingBusinessAs": [
+                {
+                    "id": 12,
+                    "verifiableOrgId": 14,
+                    "dbaName": "Gas Depot",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                },
+                {
+                    "id": 18,
+                    "verifiableOrgId": 14,
+                    "dbaName": "Gas Planet",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                }
+            ],
+            "verifiableOrg": [
+                {
+                    "id": 16,
+                    "orgId": "30042089",
+                    "orgTypeId": 1,
+                    "jurisdictionId": 1,
+                    "legalName": "Gamma Gas",
+                    "effectiveDate": "2010-10-10",
+                    "endDate": null
+                }
+            ]
+        }
         ```
         """
         return self.list(request, *args, **kwargs)


### PR DESCRIPTION
- For endpoints that return more than one type in it's result set, group the results by type to make the results more digestible.
- Update the associated API documentation.