### PR TITLE
Support for adding basic authentication to a SchemaSpy instance.

### DIFF
--- a/tob-api/openshift/templates/schema-spy/schema-spy-deploy.json
+++ b/tob-api/openshift/templates/schema-spy/schema-spy-deploy.json
@@ -40,6 +40,10 @@
       },
       "spec": {
         "host": "${NAME}-${APPLICATION_DOMAIN}",
+        "tls": {
+          "insecureEdgeTerminationPolicy": "Redirect",
+          "termination": "edge"
+        },
         "to": {
           "kind": "Service",
           "name": "${NAME}"

--- a/tob-db/openshift/schema-spy-oracle-deploy.dev.param
+++ b/tob-db/openshift/schema-spy-oracle-deploy.dev.param
@@ -11,9 +11,15 @@
 # DATABASE_CATALOG=CUAT.bcgov
 # DATABASE_HOST=142.34.88.17:1521
 # DATABASE_DRIVER=lib/ora-jdbc.jar
+# OUTPUT_PATH=/var/www/html/doc
+# SCHEMASPY_USER=[a-zA-Z_][a-zA-Z0-9_]{10}
+# SCHEMASPY_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # IMAGE_NAMESPACE=devex-von-tools
 # SOURCE_IMAGE_NAME=schema-spy-with-oracle-jdbc
 # TAG_NAME=dev
-# APPLICATION_DOMAIN=schema-spy-oracle-devex-von-dev.pathfinder.bcgov
+# APPLICATION_DOMAIN=schema-spy-oracle-devex-von-dev.pathfinder.gov.bc.ca
+# CONFIG_FILE_NAME=Caddyfile
+# CONFIG_MAP_NAME=caddy-conf
+# CONFIG_MOUNT_PATH=/etc/
 # CPU_LIMIT=2
 # MEMORY_LIMIT=2Gi

--- a/tob-db/openshift/schema-spy-oracle-deploy.overrides.sh
+++ b/tob-db/openshift/schema-spy-oracle-deploy.overrides.sh
@@ -1,0 +1,48 @@
+# ========================================================================
+# Special Deployment Parameters needed for the SchemaSpy Oracle instance.
+# ------------------------------------------------------------------------
+# The results need to be encoded as OpenShift template
+# parameters for use with oc process.
+#
+# The generated config map is used to update the Caddy configuration
+# ========================================================================
+
+CONFIG_MAP_NAME=caddy-conf
+SOURCE_FILE=./templates/Caddyfile
+OUTPUT_FORMAT=json
+OUTPUT_FILE=caddy-configmap_DeploymentConfig.json
+
+generateConfigMap() {  
+  _config_map_name=${1}
+  _source_file=${2}
+  _output_format=${3}
+  _output_file=${4}
+  if [ -z "${_config_map_name}" ] || [ -z "${_source_file}" ] || [ -z "${_output_format}" ] || [ -z "${_output_file}" ]; then
+    echo -e \\n"generateConfigMap; Missing parameter!"\\n
+    exit 1
+  fi
+
+  oc create configmap ${_config_map_name} --from-file ${_source_file} --dry-run -o ${_output_format} > ${_output_file}
+}
+
+generateUsername() {
+  # Generate a random username and Base64 encode the result ...
+  _userName=USER_$( cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 4 | head -n 1 )
+  _userName=$(echo -n "${_userName}"|base64)
+  echo ${_userName}
+}
+
+generatePassword() {
+  # Generate a random password and Base64 encode the result ...
+  _password=$( cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9_' | fold -w 16 | head -n 1 )
+  _password=$(echo -n "${_password}"|base64)  
+  echo ${_password}
+}
+
+generateConfigMap "${CONFIG_MAP_NAME}" "${SOURCE_FILE}" "${OUTPUT_FORMAT}" "${OUTPUT_FILE}"
+
+_userName=$(generateUsername)
+_password=$(generatePassword)
+SPECIALDEPLOYPARMS="-p SCHEMASPY_USER=${_userName} -p SCHEMASPY_PASSWORD=${_password}"
+echo ${SPECIALDEPLOYPARMS}
+

--- a/tob-db/openshift/schema-spy-oracle-deploy.param
+++ b/tob-db/openshift/schema-spy-oracle-deploy.param
@@ -11,9 +11,15 @@ DATABASE_SCHEMA=COLIN_MGR_UAT
 DATABASE_CATALOG=CUAT.bcgov
 DATABASE_HOST=142.34.88.17:1521
 DATABASE_DRIVER=lib/ora-jdbc.jar
+OUTPUT_PATH=/var/www/html/doc
+# SCHEMASPY_USER=[a-zA-Z_][a-zA-Z0-9_]{10}
+# SCHEMASPY_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 IMAGE_NAMESPACE=devex-von-tools
 SOURCE_IMAGE_NAME=schema-spy-with-oracle-jdbc
 TAG_NAME=dev
-APPLICATION_DOMAIN=schema-spy-oracle-devex-von-dev.pathfinder.bcgov
+APPLICATION_DOMAIN=schema-spy-oracle-devex-von-dev.pathfinder.gov.bc.ca
+CONFIG_FILE_NAME=Caddyfile
+CONFIG_MAP_NAME=caddy-conf
+CONFIG_MOUNT_PATH=/etc/
 CPU_LIMIT=2
 MEMORY_LIMIT=2Gi

--- a/tob-db/openshift/schema-spy-oracle-deploy.prod.param
+++ b/tob-db/openshift/schema-spy-oracle-deploy.prod.param
@@ -11,9 +11,15 @@
 # DATABASE_CATALOG=CUAT.bcgov
 # DATABASE_HOST=142.34.88.17:1521
 # DATABASE_DRIVER=lib/ora-jdbc.jar
+# OUTPUT_PATH=/var/www/html/doc
+# SCHEMASPY_USER=[a-zA-Z_][a-zA-Z0-9_]{10}
+# SCHEMASPY_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # IMAGE_NAMESPACE=devex-von-tools
 # SOURCE_IMAGE_NAME=schema-spy-with-oracle-jdbc
 TAG_NAME=prod
-APPLICATION_DOMAIN=schema-spy-oracle-devex-von-prod.pathfinder.bcgov
+APPLICATION_DOMAIN=schema-spy-oracle-devex-von-prod.pathfinder.gov.bc.ca
+# CONFIG_FILE_NAME=Caddyfile
+# CONFIG_MAP_NAME=caddy-conf
+# CONFIG_MOUNT_PATH=/etc/
 # CPU_LIMIT=2
 # MEMORY_LIMIT=2Gi

--- a/tob-db/openshift/schema-spy-oracle-deploy.test.param
+++ b/tob-db/openshift/schema-spy-oracle-deploy.test.param
@@ -11,9 +11,15 @@
 # DATABASE_CATALOG=CUAT.bcgov
 # DATABASE_HOST=142.34.88.17:1521
 # DATABASE_DRIVER=lib/ora-jdbc.jar
+# OUTPUT_PATH=/var/www/html/doc
+# SCHEMASPY_USER=[a-zA-Z_][a-zA-Z0-9_]{10}
+# SCHEMASPY_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # IMAGE_NAMESPACE=devex-von-tools
 # SOURCE_IMAGE_NAME=schema-spy-with-oracle-jdbc
 TAG_NAME=test
-APPLICATION_DOMAIN=schema-spy-oracle-devex-von-test.pathfinder.bcgov
+APPLICATION_DOMAIN=schema-spy-oracle-devex-von-test.pathfinder.gov.bc.ca
+# CONFIG_FILE_NAME=Caddyfile
+# CONFIG_MAP_NAME=caddy-conf
+# CONFIG_MOUNT_PATH=/etc/
 # CPU_LIMIT=2
 # MEMORY_LIMIT=2Gi

--- a/tob-db/openshift/templates/Caddyfile
+++ b/tob-db/openshift/templates/Caddyfile
@@ -1,0 +1,24 @@
+# Caddyfile for the SchemaSpy Oracle deployment.
+# This file is loaded as a config and used to transparently replace the default Caddyfile.
+# Adds basic authentication to limit access to the database documentation.
+# The root is redirected to /doc to allow an unauthenticated /health path for OpenShift
+# The deployment therefore needs to be configured to redirect the SchemaSpy
+# output to /var/www/html/doc using the OUTPUT_PATH variable.
+# The username and password need to be injected into the environment using secretes,
+# this allows the use of a generic Caddyfile for all environments while using
+# randomly generated usernames and passwords for each environment.
+
+0.0.0.0:8080 {
+  root /var/www/html
+  
+  # Openly exposed health check endpoint for OpenShift
+  status 200 /health
+  
+  # Wrap the SchemaSpy content in basic authentication
+  basicauth /doc {$SCHEMASPY_USER} {$SCHEMASPY_PASSWORD}
+  
+  # Rewrite requests to the correct location.
+  rewrite / /doc  
+  log stdout
+  errors stdouta
+}

--- a/tob-db/openshift/templates/schema-spy-oracle-deploy.json
+++ b/tob-db/openshift/templates/schema-spy-oracle-deploy.json
@@ -10,6 +10,21 @@
   },
   "objects": [
     {
+      "kind": "Secret",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "labels": {
+          "app": "${NAME}"
+        }
+      },
+      "data": {
+        "password": "${SCHEMASPY_PASSWORD}",
+        "user": "${SCHEMASPY_USER}"
+      },
+      "type": "Opaque"
+    },
+    {
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
@@ -40,6 +55,10 @@
       },
       "spec": {
         "host": "${APPLICATION_DOMAIN}",
+        "tls": {
+          "insecureEdgeTerminationPolicy": "Redirect",
+          "termination": "edge"
+        },
         "to": {
           "kind": "Service",
           "name": "${NAME}"
@@ -143,19 +162,41 @@
                     }
                   },
                   {
+                    "name": "SCHEMASPY_USER",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}",
+                        "key": "user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "SCHEMASPY_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}",
+                        "key": "password"
+                      }
+                    }
+                  },
+                  {
                     "name": "DATABASE_HOST",
                     "value": "${DATABASE_HOST}"
                   },
                   {
                     "name": "DATABASE_DRIVER",
                     "value": "${DATABASE_DRIVER}"
+                  },
+                  {
+                    "name": "OUTPUT_PATH",
+                    "value": "${OUTPUT_PATH}"
                   }
                 ],
                 "readinessProbe": {
                   "timeoutSeconds": 30,
                   "initialDelaySeconds": 3,
                   "httpGet": {
-                    "path": "/",
+                    "path": "/health",
                     "port": 8080
                   }
                 },
@@ -163,7 +204,7 @@
                   "timeoutSeconds": 30,
                   "initialDelaySeconds": 900,
                   "httpGet": {
-                    "path": "/",
+                    "path": "/health",
                     "port": 8080
                   }
                 },
@@ -172,6 +213,27 @@
                     "cpu": "${CPU_LIMIT}",
                     "memory": "${MEMORY_LIMIT}"
                   }
+                },
+                "volumeMounts": [
+                  {
+                    "name": "${NAME}-config-volume",
+                    "mountPath": "${CONFIG_MOUNT_PATH}${CONFIG_FILE_NAME}",
+                    "subPath": "${CONFIG_FILE_NAME}"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "${NAME}-config-volume",
+                "configMap": {
+                  "name": "${CONFIG_MAP_NAME}",
+                  "items": [
+                    {
+                      "key": "${CONFIG_FILE_NAME}",
+                      "path": "${CONFIG_FILE_NAME}"
+                    }
+                  ]
                 }
               }
             ]
@@ -237,6 +299,29 @@
       "value": "lib/ora-jdbc.jar"
     },
     {
+      "name": "OUTPUT_PATH",
+      "displayName": "Output Path",
+      "required": true,
+      "description": "The SchemSpy output path.",
+      "value": "/var/www/html/doc"
+    },
+    {
+      "name": "SCHEMASPY_USER",
+      "displayName": "Username for the SchemaSpy Instance",
+      "description": "Username for the SchemaSpy Instance.  Needs to be basee64 encoded.",
+      "required": true,
+      "generate": "expression",
+      "from": "[a-zA-Z_][a-zA-Z0-9_]{10}"
+    },
+    {
+      "name": "SCHEMASPY_PASSWORD",
+      "displayName": "Password for the SchemaSpy Instance",
+      "description": "Password for the SchemaSpy Instance.  Needs to be basee64 encoded.",
+      "required": true,
+      "generate": "expression",
+      "from": "[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}"
+    },
+    {
       "name": "IMAGE_NAMESPACE",
       "displayName": "Image Namespace",
       "required": true,
@@ -262,7 +347,28 @@
       "displayName": "Application Hostname",
       "description": "The exposed hostname that will route to the Django service, if left blank a value will be defaulted.",
       "value": "schema-spy-oracle-devex-von-dev.pathfinder.bcgov"
-    },    
+    },
+    {
+      "name": "CONFIG_FILE_NAME",
+      "displayName": "Config File Name",
+      "description": "The name of the configuration file.",
+      "required": true,
+      "value": "Caddyfile"
+    },
+    {
+      "name": "CONFIG_MAP_NAME",
+      "displayName": "Config Map Name",
+      "description": "The name of the configuration map.",
+      "required": true,
+      "value": "caddy-conf"
+    },
+    {
+      "name": "CONFIG_MOUNT_PATH",
+      "displayName": "Config Mount Path",
+      "description": "The path to use to mount the config file.",
+      "required": true,
+      "value": "/etc/"
+    },
     {
       "name": "CPU_LIMIT",
       "displayName": "Resources CPU Limit",


### PR DESCRIPTION
- Update configuration template and settings
- Update params files.
- Add updated Caddyfile
- Create an override script to generate the config map and credentials.
- Switch to https