### PR TITLE
Add a verifying http-did-auth-proxy pod

### DIFF
--- a/openshift/settings.sh
+++ b/openshift/settings.sh
@@ -4,12 +4,12 @@ export PROJECT_OS_DIR=${PROJECT_OS_DIR:-../../openshift}
 # The templates that should not have their GIT referances(uri and ref) over-ridden
 # Templates NOT in this list will have they GIT referances over-ridden
 # with the values of GIT_URI and GIT_REF
-export -a skip_git_overrides="schema-spy-build.json solr-base-build.json"
+export -a skip_git_overrides="schema-spy-build.json solr-base-build.json http-did-auth-proxy-build.json"
 export GIT_URI="https://github.com/bcgov/TheOrgBook.git"
 export GIT_REF="master"
 
 # The project components
-export components="tob-db tob-solr tob-api tob-web tob-ghost"
+export components="tob-db tob-solr tob-api tob-web tob-ghost tob-did-auth"
 
 # The builds to be triggered after buildconfigs created (not auto-triggered)
 export builds=""

--- a/tob-did-auth/openshift/http-did-auth-proxy-build.param
+++ b/tob-did-auth/openshift/http-did-auth-proxy-build.param
@@ -1,0 +1,10 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: tob-did-auth
+# JSON Template File: templates/http-did-auth-proxy-build.json
+#=========================================================
+NAME=http-did-auth-proxy
+GIT_REPO_URL=https://github.com/bcgov/http-did-auth-proxy.git
+GIT_REF=master
+SOURCE_CONTEXT_DIR=
+OUTPUT_IMAGE_TAG=latest

--- a/tob-did-auth/openshift/http-did-auth-proxy-deploy.dev.param
+++ b/tob-did-auth/openshift/http-did-auth-proxy-deploy.dev.param
@@ -1,0 +1,11 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: tob-did-auth
+# JSON Template File: templates/http-did-auth-proxy-deploy.json
+#=========================================================
+# NAME=http-did-auth-proxy
+# SOURCE_IMAGE_NAMESPACE=devex-von-tools
+TAG_NAME=dev
+# PORT=8080
+APPLICATION_DOMAIN=http-did-auth-proxy-devex-von-dev.pathfinder.gov.bc.ca
+# MEMORY_LIMIT=512Mi

--- a/tob-did-auth/openshift/http-did-auth-proxy-deploy.overrides.sh
+++ b/tob-did-auth/openshift/http-did-auth-proxy-deploy.overrides.sh
@@ -1,0 +1,53 @@
+# ====================================================================================
+# Special deployment configuration needed for the http-did-auth-proxy instance.
+# ------------------------------------------------------------------------------------
+# Load the http-did-auth-proxy configuration as a config map containing a set of
+# literal key/value pairs.
+# This allows the config map to be mounted as a set of environment variables.
+# ====================================================================================
+
+CONFIG_MAP_NAME=http-did-auth-proxy-config
+SOURCE_FILE_NAME=./http-did-auth-proxy
+SOURCE_FILE_EXT=.config
+OUTPUT_FORMAT=json
+OUTPUT_FILE=http-did-auth-proxy-configmap_DeploymentConfig.json
+
+generateConfigMapAsLiterals() {  
+  _config_map_name=${1}
+  _source_file=${2}
+  _output_format=${3}
+  _output_file=${4}
+  if [ -z "${_config_map_name}" ] || [ -z "${_source_file}" ] || [ -z "${_output_format}" ] || [ -z "${_output_file}" ]; then
+    echo -e \\n"generateConfigMapAsLiterals; Missing parameter!"\\n
+    exit 1
+  fi
+
+  _env_vars=$(<${_source_file})
+  for _var in ${_env_vars}; do
+    _literals="${_literals} --from-literal=${_var}"
+  done
+
+  oc create configmap ${_config_map_name} ${_literals} --dry-run -o ${_output_format} > ${_output_file}
+}
+
+resolveSourceFile() {
+  _source_file_name=${1}
+  _source_file_ext=${2}
+  _env_name=${3}
+
+  if [ ! -z "${_env_name}" ]; then
+    _source_file="${_source_file_name}.${_env_name}${_source_file_ext}"
+  fi
+
+  if [ -f "${_source_file}" ]; then
+    echo "${_source_file}"
+  else
+    echo "${_source_file_name}${_source_file_ext}"
+  fi
+}
+
+SOURCE_FILE=$(resolveSourceFile "${SOURCE_FILE_NAME}" "${SOURCE_FILE_EXT}" "${DEPLOYMENT_ENV_NAME}")
+generateConfigMapAsLiterals "${CONFIG_MAP_NAME}" "${SOURCE_FILE}" "${OUTPUT_FORMAT}" "${OUTPUT_FILE}"
+
+echo ${SPECIALDEPLOYPARMS}
+

--- a/tob-did-auth/openshift/http-did-auth-proxy-deploy.param
+++ b/tob-did-auth/openshift/http-did-auth-proxy-deploy.param
@@ -1,0 +1,11 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: tob-did-auth
+# JSON Template File: templates/http-did-auth-proxy-deploy.json
+#=========================================================
+NAME=http-did-auth-proxy
+SOURCE_IMAGE_NAMESPACE=devex-von-tools
+TAG_NAME=dev
+PORT=8080
+APPLICATION_DOMAIN=http-did-auth-proxy-devex-von-dev.pathfinder.gov.bc.ca
+MEMORY_LIMIT=512Mi

--- a/tob-did-auth/openshift/http-did-auth-proxy-deploy.prod.param
+++ b/tob-did-auth/openshift/http-did-auth-proxy-deploy.prod.param
@@ -1,0 +1,11 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: tob-did-auth
+# JSON Template File: templates/http-did-auth-proxy-deploy.json
+#=========================================================
+# NAME=http-did-auth-proxy
+# SOURCE_IMAGE_NAMESPACE=devex-von-tools
+TAG_NAME=prod
+# PORT=8080
+APPLICATION_DOMAIN=http-did-auth-proxy-devex-von-prod.pathfinder.gov.bc.ca
+# MEMORY_LIMIT=512Mi

--- a/tob-did-auth/openshift/http-did-auth-proxy-deploy.test.param
+++ b/tob-did-auth/openshift/http-did-auth-proxy-deploy.test.param
@@ -1,0 +1,11 @@
+#=========================================================
+# OpenShift template parameters for:
+# Component: tob-did-auth
+# JSON Template File: templates/http-did-auth-proxy-deploy.json
+#=========================================================
+# NAME=http-did-auth-proxy
+# SOURCE_IMAGE_NAMESPACE=devex-von-tools
+TAG_NAME=test
+# PORT=8080
+APPLICATION_DOMAIN=http-did-auth-proxy-devex-von-test.pathfinder.gov.bc.ca
+# MEMORY_LIMIT=512Mi

--- a/tob-did-auth/openshift/http-did-auth-proxy.config
+++ b/tob-did-auth/openshift/http-did-auth-proxy.config
@@ -1,0 +1,4 @@
+signing=0
+resolverUri=https://uniresolver.io/1.0/identifiers/
+targetHost=httpbin.org:80
+whitelist=did:sov:DavnUKB3kjn7VmVZXzEDL7,did:v1:test:nym:rZdPg5VF6SqrVuEYEHAuDaeikkA2D8QBLRJQRnhz3pI

--- a/tob-did-auth/openshift/http-did-auth-proxy.dev.config
+++ b/tob-did-auth/openshift/http-did-auth-proxy.dev.config
@@ -1,0 +1,4 @@
+signing=0
+resolverUri=https://uniresolver.io/1.0/identifiers/
+targetHost=httpbin.org:80
+whitelist=did:sov:DavnUKB3kjn7VmVZXzEDL7,did:v1:test:nym:rZdPg5VF6SqrVuEYEHAuDaeikkA2D8QBLRJQRnhz3pI

--- a/tob-did-auth/openshift/templates/http-did-auth-proxy-build.json
+++ b/tob-did-auth/openshift/templates/http-did-auth-proxy-build.json
@@ -1,0 +1,95 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "annotations": {
+      "description": "Build template for ${NAME}.",
+      "tags": "${name}"
+    },
+    "name": "${NAME}-build-template"
+  },
+  "objects": [
+    {
+        "kind": "ImageStream",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": "${NAME}"
+        }
+    },
+    {
+      "kind": "BuildConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "labels": {
+          "app": "${NAME}",
+          "buildconfig": "${NAME}"
+        }
+      },
+      "spec": {
+        "source": {
+          "type": "Git",
+          "git": {
+            "uri": "${GIT_REPO_URL}",
+            "ref": "${GIT_REF}"
+          },
+          "contextDir": "${SOURCE_CONTEXT_DIR}"
+        },
+        "strategy": {
+          "type": "Docker"
+        },
+        "output": {
+          "to": {
+            "kind": "ImageStreamTag",
+            "name": "${NAME}:${OUTPUT_IMAGE_TAG}"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange"
+          }
+        ]
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the objects defined in this template.",
+      "required": true,
+      "value": "http-did-auth-proxy"
+    },
+    {
+      "name": "GIT_REPO_URL",
+      "displayName": "Git Repo URL",
+      "description": "The URL to the Git repository containing the source code for the build.",
+      "required": true,
+      "value": "https://github.com/bcgov/http-did-auth-proxy.git"
+    },
+    {
+      "name": "GIT_REF",
+      "displayName": "Git Reference",
+      "description": "The git reference or branch containing the source code for the build.",
+      "required": true,
+      "value": "master"
+    },
+    {
+      "name": "SOURCE_CONTEXT_DIR",
+      "displayName": "Source Context Directory",
+      "description": "The directory containing the source code, if not the root of the repository.",
+      "required": false,
+      "value": ""
+    },
+    {
+      "name": "OUTPUT_IMAGE_TAG",
+      "displayName": "Output Image Tag",
+      "description": "The tag given to the built image.",
+      "required": true,
+      "value": "latest"
+    }
+  ]
+}

--- a/tob-did-auth/openshift/templates/http-did-auth-proxy-deploy.json
+++ b/tob-did-auth/openshift/templates/http-did-auth-proxy-deploy.json
@@ -1,0 +1,186 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "${NAME}-deployment-template",
+    "annotations": {
+      "description": "Deployment template for ${NAME}.",
+      "tags": "${NAME}"
+    }
+  },
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "annotations": {
+          "description": "Exposes and load balances the application pods."
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "${PORT}-tcp",
+            "protocol": "TCP",
+            "port": "${{PORT}}",
+            "targetPort": "${{PORT}}"
+          }
+        ],
+        "selector": {
+          "name": "${NAME}"
+        }
+      }
+    },
+    {
+      "kind": "Route",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}"
+      },
+      "spec": {
+        "host": "${APPLICATION_DOMAIN}",
+        "port": {
+          "targetPort": "${PORT}-tcp"
+        },
+        "tls": {
+          "insecureEdgeTerminationPolicy": "Redirect",
+          "termination": "edge"
+        },
+        "to": {
+          "kind": "Service",
+          "name": "${NAME}",
+          "weight": 100
+        }
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "annotations": {
+          "description": "Defines how to deploy the container."
+        }
+      },
+      "spec": {
+        "strategy": {
+          "type": "Rolling",
+          "rollingParams": {
+            "updatePeriodSeconds": 1,
+            "intervalSeconds": 1,
+            "timeoutSeconds": 600,
+            "maxUnavailable": "25%",
+            "maxSurge": "25%"
+          }
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          },
+          {
+            "type": "ImageChange",
+            "imageChangeParams": {
+              "automatic": true,
+              "containerNames": [
+                "${NAME}"
+              ],
+              "from": {
+                "kind": "ImageStreamTag",
+                "namespace": "${SOURCE_IMAGE_NAMESPACE}",
+                "name": "${NAME}:${TAG_NAME}"
+              }
+            }
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "${NAME}"
+        },
+        "template": {
+          "metadata": {
+            "name": "${NAME}",
+            "labels": {
+              "name": "${NAME}"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "${NAME}",
+                "image": " ",
+                "ports": [
+                  {
+                    "containerPort": "${{PORT}}",
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "port",
+                    "value": "${PORT}"
+                  }
+                ],
+                "envFrom": [
+                  {
+                    "configMapRef": {
+                      "name": "${NAME}-config"
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "memory": "${MEMORY_LIMIT}"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAME",
+      "displayName": "Name",
+      "description": "The name assigned to all of the objects defined in this template.",
+      "required": true,
+      "value": "http-did-auth-proxy"
+    },
+    {
+      "name": "SOURCE_IMAGE_NAMESPACE",
+      "displayName": "Image Namespace",
+      "description": "The namespace of the OpenShift project containing the imagestream for the application.",
+      "required": true,
+      "value": "devex-von-bc-registries-agent-tools"
+    },
+    {
+      "name": "TAG_NAME",
+      "displayName": "Environment TAG name",
+      "description": "The TAG name for this environment, e.g., dev, test, prod",
+      "required": true,
+      "value": "dev"
+    },
+    {
+      "name": "PORT",
+      "displayName": "Listening Port",
+      "description": "The port on which the proxy will listen; default 8080.",
+      "required": true,
+      "value": "8080"
+    },
+    {
+      "name": "APPLICATION_DOMAIN",
+      "displayName": "Application Hostname",
+      "description": "The exposed hostname that will route to the Django service, if left blank a value will be defaulted.",
+      "value": ""
+    },    
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "required": true,
+      "description": "Maximum amount of memory the container can use.",
+      "value": "512Mi"
+    }
+  ]
+}


### PR DESCRIPTION
- Build and deployment templates and parameters
- Configuration files to configure the proxy in verifying mode with a white-list.

The proxy configuration is from the documented examples.  This initial configuration is meant for verifying setting and communication with a deployed signing proxy with a matching configuration.

The proxy is currently standalone.