### PR TITLE
Unwind process and instance limitations

### DIFF
--- a/tob-api/openshift/django-deploy.dev.param
+++ b/tob-api/openshift/django-deploy.dev.param
@@ -5,7 +5,6 @@
 #=========================================================
 # NAME=django
 # IMAGE_NAMESPACE=devex-von-tools
-# MEMORY_LIMIT=512Mi
 APPLICATION_DOMAIN=django-devex-von-dev.pathfinder.gov.bc.ca
 # DATABASE_SERVICE_NAME=postgresql
 # DATABASE_ENGINE=postgresql
@@ -17,10 +16,9 @@ APPLICATION_DOMAIN=django-devex-von-dev.pathfinder.gov.bc.ca
 # SOLR_CORE_NAME=the_org_book
 TAG_NAME=dev
 # DATABASE_DEPLOYMENT_NAME=postgresql
-# PERSISTENT_VOLUME_SIZE=1Gi
-# MOUNT_PATH=/opt/app-root/src/.indy_client
 INDY_WALLET_SEED=the_org_book_dev_000000000000000
 LEDGER_URL=http://159.89.115.24
 # INDY_WALLET_TYPE=remote
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
+# MEMORY_LIMIT=512Mi

--- a/tob-api/openshift/django-deploy.param
+++ b/tob-api/openshift/django-deploy.param
@@ -5,7 +5,6 @@
 #=========================================================
 NAME=django
 IMAGE_NAMESPACE=devex-von-tools
-MEMORY_LIMIT=512Mi
 APPLICATION_DOMAIN=django-devex-von-dev.pathfinder.gov.bc.ca
 DATABASE_SERVICE_NAME=postgresql
 DATABASE_ENGINE=postgresql
@@ -17,10 +16,9 @@ SOLR_SERVICE_NAME=solr
 SOLR_CORE_NAME=the_org_book
 TAG_NAME=dev
 DATABASE_DEPLOYMENT_NAME=postgresql
-PERSISTENT_VOLUME_SIZE=1Gi
-MOUNT_PATH=/opt/app-root/src/.indy_client
 INDY_WALLET_SEED=the_org_book_dev_000000000000000
 LEDGER_URL=http://159.89.115.24
 INDY_WALLET_TYPE=remote
 INDY_WALLET_URL=http://wallet:8080/api/v1/
 WALLET_DEPLOYMENT_NAME=wallet
+MEMORY_LIMIT=512Mi

--- a/tob-api/openshift/django-deploy.prod.param
+++ b/tob-api/openshift/django-deploy.prod.param
@@ -5,7 +5,6 @@
 #=========================================================
 # NAME=django
 # IMAGE_NAMESPACE=devex-von-tools
-# MEMORY_LIMIT=512Mi
 APPLICATION_DOMAIN=django-devex-von-prod.pathfinder.gov.bc.ca
 # DATABASE_SERVICE_NAME=postgresql
 # DATABASE_ENGINE=postgresql
@@ -17,10 +16,9 @@ DJANGO_DEBUG=False
 # SOLR_CORE_NAME=the_org_book
 TAG_NAME=prod
 # DATABASE_DEPLOYMENT_NAME=postgresql
-# PERSISTENT_VOLUME_SIZE=1Gi
-# MOUNT_PATH=/opt/app-root/src/.indy_client
 INDY_WALLET_SEED=the_org_book_prod_00000000000000
 LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_TYPE=remote
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
+# MEMORY_LIMIT=512Mi

--- a/tob-api/openshift/django-deploy.test.param
+++ b/tob-api/openshift/django-deploy.test.param
@@ -5,7 +5,6 @@
 #=========================================================
 # NAME=django
 # IMAGE_NAMESPACE=devex-von-tools
-# MEMORY_LIMIT=512Mi
 APPLICATION_DOMAIN=django-devex-von-test.pathfinder.gov.bc.ca
 # DATABASE_SERVICE_NAME=postgresql
 # DATABASE_ENGINE=postgresql
@@ -17,10 +16,9 @@ APPLICATION_DOMAIN=django-devex-von-test.pathfinder.gov.bc.ca
 # SOLR_CORE_NAME=the_org_book
 TAG_NAME=test
 # DATABASE_DEPLOYMENT_NAME=postgresql
-# PERSISTENT_VOLUME_SIZE=1Gi
-# MOUNT_PATH=/opt/app-root/src/.indy_client
 INDY_WALLET_SEED=the_org_book_test_00000000000000
 LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_TYPE=remote
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
+# MEMORY_LIMIT=512Mi

--- a/tob-api/openshift/templates/django/django-deploy.json
+++ b/tob-api/openshift/templates/django/django-deploy.json
@@ -56,27 +56,6 @@
       }
     },
     {
-      "kind": "PersistentVolumeClaim",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "${NAME}",
-        "labels": {
-          "app": "${NAME}",
-          "template": "${NAME}-deployment-template"
-        }
-      },
-      "spec": {
-        "accessModes": [
-          "ReadWriteOnce"
-        ],
-        "resources": {
-          "requests": {
-            "storage": "${PERSISTENT_VOLUME_SIZE}"
-          }
-        }
-      }
-    },
-    {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
@@ -120,14 +99,6 @@
             }
           },
           "spec": {
-            "volumes": [
-              {
-                "name": "${NAME}-data",
-                "persistentVolumeClaim": {
-                  "claimName": "${NAME}"
-                }
-              }
-            ],
             "containers": [
               {
                 "name": "${NAME}",
@@ -154,12 +125,6 @@
                     "port": 8080
                   }
                 },
-                "volumeMounts": [
-                  {
-                    "name": "${NAME}-data",
-                    "mountPath": "${MOUNT_PATH}"
-                  }
-                ],
                 "env": [
                   {
                     "name": "DATABASE_SERVICE_NAME",
@@ -256,24 +221,6 @@
           }
         }
       }
-    },
-    {
-      "kind": "HorizontalPodAutoscaler",
-      "apiVersion": "autoscaling/v1",
-      "metadata": {
-        "name": "${NAME}",
-        "labels": {
-          "app": "${NAME}"
-        }
-      },
-      "spec": {
-        "scaleTargetRef": {
-          "kind": "DeploymentConfig",
-          "name": "${NAME}"
-        },
-        "minReplicas": 1,
-        "maxReplicas": 1
-      }
     }
   ],
   "parameters": [
@@ -290,13 +237,6 @@
       "required": true,
       "description": "The namespace of the OpenShift project containing the imagestream for the application.",
       "value": "devex-von-tools"
-    },
-    {
-      "name": "MEMORY_LIMIT",
-      "displayName": "Memory Limit",
-      "required": true,
-      "description": "Maximum amount of memory the Django container can use.",
-      "value": "512Mi"
     },
     {
       "name": "APPLICATION_DOMAIN",
@@ -373,20 +313,6 @@
       "value": "postgresql"
     },
     {
-      "name": "PERSISTENT_VOLUME_SIZE",
-      "displayName": "Persistent Volume Size",
-      "description": "The size of the persistent volume , e.g. 512Mi, 1Gi, 2Gi.",
-      "required": true,
-      "value": "1Gi"
-    },
-    {
-      "name": "MOUNT_PATH",
-      "displayName": "Mount Path",
-      "description": "The path to mount the persistent volume.",
-      "required": true,
-      "value": "/opt/app-root/src/.indy_client"
-    },
-    {
       "name": "INDY_WALLET_SEED",
       "displayName": "Indy Wallet Seed",
       "description": "The seed that the indy wallet uses to generate predictable keys.",
@@ -420,6 +346,13 @@
       "description": "The name associated to the wallet deployment resources.  In particular, this is used to wire up the credentials associated to the wallet.",
       "required": true,
       "value": "wallet"
-    }
+    },
+    {
+      "name": "MEMORY_LIMIT",
+      "displayName": "Memory Limit",
+      "required": true,
+      "description": "Maximum amount of memory the Django container can use.",
+      "value": "512Mi"
+    }    
   ]
 }

--- a/tob-api/openshift/templates/python-libindy/s2i/bin/run
+++ b/tob-api/openshift/templates/python-libindy/s2i/bin/run
@@ -17,14 +17,6 @@ function should_migrate() {
 
 # Guess the number of workers according to the number of cores
 function get_default_web_concurrency() {
-
-  
-  # We limit processes to 1 since libindy wallet 
-  # can only be used by 1 process
-  echo 1
-  return
-
-
   limit_vars=$(cgroup-limits)
   local $limit_vars
   if [ -z "${NUMBER_OF_CORES:-}" ]; then


### PR DESCRIPTION
Unwind the process and instance limitations imposed by the initial wallet implementation.

Now that we are using the enterprise wallet we don't need to;
- Have local storage for the wallet
- Limit the number of gunicorn (host) processes.
- Limit the number of tob-api instances.