### PR TITLE
Add support for controlling the number of gunicorn workers

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - WALLET_ADMIN_USER_ID=${WALLET_ADMIN_USER_ID}
       - WALLET_ADMIN_PASSWORD=${WALLET_ADMIN_PASSWORD}
       - STI_SCRIPTS_PATH=${STI_SCRIPTS_PATH}
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY}
     volumes:
       - ../tob-wallet/api:/opt/app-root/src/api
     networks:
@@ -102,6 +103,7 @@ services:
       - WALLET_USER_ID=${WALLET_USER_ID}
       - WALLET_PASSWORD=${WALLET_USER_PASSWORD}
       - STI_SCRIPTS_PATH=${STI_SCRIPTS_PATH}
+      - WEB_CONCURRENCY=${WEB_CONCURRENCY}
     volumes:
       - ../tob-api/api:/opt/app-root/src/api
     networks:


### PR DESCRIPTION
- WEB_CONCURRENCY is used to control the number of gunicorn workers that get created.
  The previous restrictions we had in place were equivalent to WEB_CONCURRENCY=1
  When left undefined the scripts calculate the number of workers based on the
  available resources.