### PR TITLE
#338 - Refactor Client/API basic authorization configuration.

### DIFF
--- a/tob-api/openshift/django-deploy.bc-tob.dev.param
+++ b/tob-api/openshift/django-deploy.bc-tob.dev.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.115.24
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=bcgov
+USE_AUTHENTICATION=True
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.bc-tob.param
+++ b/tob-api/openshift/django-deploy.bc-tob.param
@@ -22,6 +22,11 @@ INDY_WALLET_TYPE=remote
 INDY_WALLET_URL=http://wallet:8080/api/v1/
 WALLET_DEPLOYMENT_NAME=wallet
 TOB_THEME=bcgov
+USE_AUTHENTICATION=True
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 CPU_LIMIT=1
 MEMORY_LIMIT=1.5Gi
 CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.bc-tob.prod.param
+++ b/tob-api/openshift/django-deploy.bc-tob.prod.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=bcgov
+USE_AUTHENTICATION=True
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.bc-tob.test.param
+++ b/tob-api/openshift/django-deploy.bc-tob.test.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=bcgov
+USE_AUTHENTICATION=True
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.dev.param
+++ b/tob-api/openshift/django-deploy.dev.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.115.24
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=bcgov
+USE_AUTHENTICATION=False
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.ontario.dev.param
+++ b/tob-api/openshift/django-deploy.ontario.dev.param
@@ -22,6 +22,11 @@ INDY_WALLET_SEED=the_org_book_on_dev_000000000000
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=ongov
+USE_AUTHENTICATION=False
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.ontario.param
+++ b/tob-api/openshift/django-deploy.ontario.param
@@ -22,6 +22,11 @@ INDY_WALLET_TYPE=remote
 INDY_WALLET_URL=http://wallet:8080/api/v1/
 WALLET_DEPLOYMENT_NAME=wallet
 TOB_THEME=ongov
+USE_AUTHENTICATION=False
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 CPU_LIMIT=1
 MEMORY_LIMIT=1.5Gi
 CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.ontario.prod.param
+++ b/tob-api/openshift/django-deploy.ontario.prod.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=ongov
+USE_AUTHENTICATION=True
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.ontario.test.param
+++ b/tob-api/openshift/django-deploy.ontario.test.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=ongov
+USE_AUTHENTICATION=False
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.overrides.sh
+++ b/tob-api/openshift/django-deploy.overrides.sh
@@ -1,9 +1,9 @@
-# =========================================================
-# Special Deployment Parameters needed for Nginx Deployment
-# ---------------------------------------------------------
+# ======================================================
+# Special Deployment Parameters for basic authentication
+# ------------------------------------------------------
 # The results need to be encoded as OpenShift template
 # parameters for use with oc process.
-# =========================================================
+# ======================================================
 
 generateUsername() {
   # Generate a random username and Base64 encode the result ...
@@ -21,7 +21,9 @@ generatePassword() {
 
 _userName=$(generateUsername)
 _password=$(generatePassword)
+_adminUserName=$(generateUsername)
+_adminPassword=$(generatePassword)
 
-SPECIALDEPLOYPARMS="-p HTTP_BASIC_USERNAME=${_userName} -p HTTP_BASIC_PASSWORD=${_password}"
+SPECIALDEPLOYPARMS="-p USER_ID=${_userName} -p USER_PASSWORD=${_password} -p ADMIN_USER_ID=${_adminUserName} -p ADMIN_PASSWORD=${_adminPassword}"
 echo ${SPECIALDEPLOYPARMS}
 

--- a/tob-api/openshift/django-deploy.param
+++ b/tob-api/openshift/django-deploy.param
@@ -22,6 +22,11 @@ INDY_WALLET_TYPE=remote
 INDY_WALLET_URL=http://wallet:8080/api/v1/
 WALLET_DEPLOYMENT_NAME=wallet
 TOB_THEME=bcgov
+USE_AUTHENTICATION=False
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 CPU_LIMIT=1
 MEMORY_LIMIT=1.5Gi
 CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.prod.param
+++ b/tob-api/openshift/django-deploy.prod.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=bcgov
+USE_AUTHENTICATION=True
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/django-deploy.test.param
+++ b/tob-api/openshift/django-deploy.test.param
@@ -22,6 +22,11 @@ LEDGER_URL=http://159.89.125.134
 # INDY_WALLET_URL=http://wallet:8080/api/v1/
 # WALLET_DEPLOYMENT_NAME=wallet
 # TOB_THEME=bcgov
+USE_AUTHENTICATION=False
+# USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# USER_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
+# ADMIN_USER_ID=[a-zA-Z_][a-zA-Z0-9_]{10}
+# ADMIN_PASSWORD=[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}
 # CPU_LIMIT=1
 # MEMORY_LIMIT=1.5Gi
 # CPU_REQUEST=250m

--- a/tob-api/openshift/templates/django/django-deploy.json
+++ b/tob-api/openshift/templates/django/django-deploy.json
@@ -11,6 +11,23 @@
   },
   "objects": [
     {
+      "kind": "Secret",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "${NAME}",
+        "labels": {
+          "app": "${NAME}"
+        }
+      },
+      "data": {
+        "api-user": "${USER_ID}",
+        "api-password": "${USER_PASSWORD}",
+        "admin-user": "${ADMIN_USER_ID}",
+        "admin-password": "${ADMIN_PASSWORD}"
+      },
+      "type": "Opaque"
+    },
+    {
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
@@ -215,6 +232,46 @@
                     }
                   },
                   {
+                    "name": "USE_AUTHENTICATION",
+                    "value": "${USE_AUTHENTICATION}"
+                  },
+                  {
+                    "name": "USER_ID",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}",
+                        "key": "api-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "USER_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}",
+                        "key": "api-password"
+                      }
+                    }
+                  },
+                  {
+                    "name": "ADMIN_USER_ID",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}",
+                        "key": "admin-user"
+                      }
+                    }
+                  },
+                  {
+                    "name": "ADMIN_PASSWORD",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "${NAME}",
+                        "key": "admin-password"
+                      }
+                    }
+                  },
+                  {
                     "name": "TOB_THEME",
                     "value": "${TOB_THEME}"
                   }
@@ -384,6 +441,45 @@
       "description": "The theme to use for the tob-api.  This defines which customizations to load for the application.",
       "required": true,
       "value": "bcgov"
+    },
+    {
+      "name": "USE_AUTHENTICATION",
+      "displayName": "Use Authentication",
+      "description": "Enable or disable the use of authentication on the API.  When set to `False` the API will be unprotected.",
+      "required": true,
+      "value": "False"
+    },
+    {
+      "name": "USER_ID",
+      "displayName": "API Username",
+      "description": "Username for the account that will be used for accessing the API.  Needs to be basee64 encoded.",
+      "required": true,
+      "generate": "expression",
+      "from": "[a-zA-Z_][a-zA-Z0-9_]{10}"
+    },
+    {
+      "name": "USER_PASSWORD",
+      "displayName": "API Password",
+      "description": "Password for the account that will be used for accessing the API.  Needs to be basee64 encoded.",
+      "required": true,
+      "generate": "expression",
+      "from": "[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}"
+    },
+    {
+      "name": "ADMIN_USER_ID",
+      "displayName": "API Admin Username",
+      "description": "Username for the API superuser account.  Needs to be basee64 encoded.",
+      "required": true,
+      "generate": "expression",
+      "from": "[a-zA-Z_][a-zA-Z0-9_]{10}"
+    },
+    {
+      "name": "ADMIN_PASSWORD",
+      "displayName": "API Admin Password",
+      "description": "Password for the API superuser account.  Needs to be basee64 encoded.",
+      "required": true,
+      "generate": "expression",
+      "from": "[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}"
     },
     {
       "name": "CPU_LIMIT",

--- a/tob-web/openshift/angular-on-nginx-deploy.bc-tob.dev.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.bc-tob.dev.param
@@ -14,6 +14,4 @@
 # APPLICATION_DOMAIN=angular-on-nginx-devex-von-bc-tob-dev.pathfinder.gov.bc.ca
 # TAG_NAME=dev
 # HTTP_BASIC=auth_basic 'restricted';
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.bc-tob.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.bc-tob.param
@@ -14,6 +14,4 @@ IpFilterRules=
 APPLICATION_DOMAIN=angular-on-nginx-devex-von-bc-tob-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
 HTTP_BASIC=auth_basic 'restricted';
-HTTP_BASIC_USERNAME=
-HTTP_BASIC_PASSWORD=
 TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.bc-tob.prod.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.bc-tob.prod.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=angular-on-nginx-devex-von-bc-tob-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
 # HTTP_BASIC=auth_basic 'restricted';
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.bc-tob.test.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.bc-tob.test.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=angular-on-nginx-devex-von-bc-tob-test.pathfinder.gov.bc.ca
 TAG_NAME=test
 # HTTP_BASIC=auth_basic 'restricted';
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.dev.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.dev.param
@@ -14,6 +14,4 @@
 # APPLICATION_DOMAIN=angular-on-nginx-devex-von-dev.pathfinder.gov.bc.ca
 # TAG_NAME=dev
 # HTTP_BASIC=
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.ontario.dev.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.ontario.dev.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=ontvon-von-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
 # HTTP_BASIC=
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=ongov

--- a/tob-web/openshift/angular-on-nginx-deploy.ontario.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.ontario.param
@@ -14,6 +14,4 @@ IpFilterRules=
 APPLICATION_DOMAIN=ontvon-von-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
 HTTP_BASIC=
-HTTP_BASIC_USERNAME=
-HTTP_BASIC_PASSWORD=
 TOB_THEME=ongov

--- a/tob-web/openshift/angular-on-nginx-deploy.ontario.prod.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.ontario.prod.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=ontvon-von-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
 # HTTP_BASIC=
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=ongov

--- a/tob-web/openshift/angular-on-nginx-deploy.ontario.test.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.ontario.test.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=ontvon-von-test.pathfinder.gov.bc.ca
 TAG_NAME=test
 # HTTP_BASIC=
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=ongov

--- a/tob-web/openshift/angular-on-nginx-deploy.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.param
@@ -14,6 +14,4 @@ IpFilterRules=
 APPLICATION_DOMAIN=angular-on-nginx-devex-von-dev.pathfinder.gov.bc.ca
 TAG_NAME=dev
 HTTP_BASIC=
-HTTP_BASIC_USERNAME=
-HTTP_BASIC_PASSWORD=
 TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.prod.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.prod.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=angular-on-nginx-devex-von-prod.pathfinder.gov.bc.ca
 TAG_NAME=prod
 # HTTP_BASIC=
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=bcgov

--- a/tob-web/openshift/angular-on-nginx-deploy.test.param
+++ b/tob-web/openshift/angular-on-nginx-deploy.test.param
@@ -14,6 +14,4 @@
 APPLICATION_DOMAIN=angular-on-nginx-devex-von-test.pathfinder.gov.bc.ca
 TAG_NAME=test
 # HTTP_BASIC=
-# HTTP_BASIC_USERNAME=
-# HTTP_BASIC_PASSWORD=
 # TOB_THEME=bcgov

--- a/tob-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
+++ b/tob-web/openshift/templates/angular-on-nginx/angular-on-nginx-deploy.json
@@ -10,21 +10,6 @@
   },
   "objects": [
     {
-      "kind": "Secret",
-      "apiVersion": "v1",
-      "metadata": {
-        "name": "${NAME}",
-        "labels": {
-          "app": "${NAME}"
-        }
-      },
-      "data": {
-        "password": "${HTTP_BASIC_PASSWORD}",
-        "user": "${HTTP_BASIC_USERNAME}"
-      },
-      "type": "Opaque"
-    },
-    {
       "apiVersion": "v1",
       "kind": "DeploymentConfig",
       "metadata": {
@@ -103,8 +88,8 @@
                     "name": "HTTP_BASIC_USERNAME",
                     "valueFrom": {
                       "secretKeyRef": {
-                        "name": "${NAME}",
-                        "key": "user"
+                        "name": "${API_SERVICE_NAME}",
+                        "key": "api-user"
                       }
                     }
                   },
@@ -112,8 +97,8 @@
                     "name": "HTTP_BASIC_PASSWORD",
                     "valueFrom": {
                       "secretKeyRef": {
-                        "name": "${NAME}",
-                        "key": "password"
+                        "name": "${API_SERVICE_NAME}",
+                        "key": "api-password"
                       }
                     }
                   },
@@ -325,26 +310,10 @@
       "value": "dev"
     },
     {
-      "description": "For very simple HTTP Basic authentication, use %HTTP_BASIC% in your nginx config and provide the value here that you want in nginx config, e.g., auth_basic 'restricted';",
+      "description": "For very simple HTTP Basic authentication, use %HTTP_BASIC% in your nginx config and provide the value here that you want in nginx config, e.g., `auth_basic 'restricted';`",
       "displayName": "HTTP Basic Nginx Config Line",
       "name": "HTTP_BASIC",
       "value": ""
-    },
-    {
-      "description": "For very simple HTTP Basic authentication, the username of the ONE user",
-      "displayName": "HTTP Basic Username",
-      "name": "HTTP_BASIC_USERNAME",
-      "required": true,
-      "generate": "expression",
-      "from": "[a-zA-Z_][a-zA-Z0-9_]{10}"
-    },
-    {
-      "description": "For very simple HTTP Basic authentication, the password of the ONE user",
-      "displayName": "HTTP Basic Password",
-      "name": "HTTP_BASIC_PASSWORD",
-      "required": true,
-      "generate": "expression",
-      "from": "[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]{16}"
     },
     {
       "name": "TOB_THEME",


### PR DESCRIPTION
- When using simple basic authentication, configure the credentials on the API side and inject them into the client.  The client needs to be able to authenticate with the API in order to function.