### PR TITLE
Update nginx conf to redirect /api/v2 to API deployment

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -250,7 +250,7 @@ configureEnvironment() {
   export LEDGER_PROTOCOL_VERSION=${LEDGER_PROTOCOL_VERSION-}
   export SQL_DEBUG=${SQL_DEBUG:-}
   export WEB_CONCURRENCY=${WEB_CONCURRENCY:-5}
-  export APPLICATION_URL=${APPLICATION_URL-http://localhost:8081}
+  export APPLICATION_URL=${APPLICATION_URL-http://localhost:8080}
 
   # tob-web
   export TOB_THEME=${TOB_THEME:-bcgov}

--- a/openshift/settings.bc-tob.sh
+++ b/openshift/settings.bc-tob.sh
@@ -6,4 +6,4 @@ export PROJECT_NAMESPACE="devex-von-bc-tob"
 # The project components
 export components="tob-db tob-solr tob-api tob-web tob-wallet tob-backup"
 
-export -a skip_git_overrides="${skip_git_overrides} backup-build.json"
+export skip_git_overrides="${skip_git_overrides} backup-build.json"

--- a/openshift/settings.ontario.sh
+++ b/openshift/settings.ontario.sh
@@ -3,4 +3,4 @@ export PROJECT_NAMESPACE="ontvon-von"
 # The project components
 export components="tob-db tob-solr tob-api tob-web tob-wallet tob-backup"
 
-export -a skip_git_overrides="${skip_git_overrides} backup-build.json"
+export skip_git_overrides="${skip_git_overrides} backup-build.json"

--- a/openshift/settings.sh
+++ b/openshift/settings.sh
@@ -4,7 +4,7 @@ export PROJECT_OS_DIR=${PROJECT_OS_DIR:-../../openshift}
 # The templates that should not have their GIT referances(uri and ref) over-ridden
 # Templates NOT in this list will have they GIT referances over-ridden
 # with the values of GIT_URI and GIT_REF
-export -a skip_git_overrides="schema-spy-build.json solr-base-build.json"
+export skip_git_overrides="schema-spy-build.json solr-base-build.json"
 export GIT_URI="https://github.com/bcgov/TheOrgBook.git"
 export GIT_REF="master"
 

--- a/tob-api/api_v2/urls.py
+++ b/tob-api/api_v2/urls.py
@@ -16,9 +16,17 @@ schema_view = get_schema_view(
     openapi.Info(
         title="TheOrgBook API",
         default_version="v2",
-        # description="Description goes here",
+        description="TheOrgBook is a public searchable directory of digital records for registered businesses in the Province "
+        "of British Columbia. Over time, other government organizations and businesses will also begin to issue"
+        "digital records through TheOrgBook. For example, permits and licenses issued by various government services.",
+        terms_of_service="https://www2.gov.bc.ca/gov/content/data/open-data",
+        contact=openapi.Contact(email="bcdevexchange@gov.bc.ca"),
+        license=openapi.License(
+            name="Open Government License - British Columbia",
+            url="https://www2.gov.bc.ca/gov/content/data/open-data/api-terms-of-use-for-ogl-information",
+        ),
     ),
-    url="{}/api/v2".format(APPLICATION_URL),
+    url="{}/api".format(APPLICATION_URL),
     validators=["flex", "ssv"],
     public=True,
     permission_classes=(AllowAny,),
@@ -45,12 +53,10 @@ router.register(r"search/credential", search.CredentialSearchView, "Credential S
 searchPatterns = [url(r"^search/autocomplete$", search.NameAutocompleteView.as_view())]
 
 # Misc endpoints
-miscPatterns = [
-    url(r"^quickload$", misc.quickload)
-]
+miscPatterns = [url(r"^quickload$", misc.quickload)]
 
 swaggerPatterns = [
-    url(r"^$", schema_view.with_ui("swagger", cache_timeout=None), name="api-docs"),
+    url(r"^$", schema_view.with_ui("swagger", cache_timeout=None), name="api-docs")
 ]
 
 urlpatterns = format_suffix_patterns(

--- a/tob-web/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/tob-web/openshift/templates/nginx-runtime/s2i/bin/run
@@ -31,6 +31,14 @@ read -r -d '' _CONFIG_SECTION << EOF
             proxy_set_header X-Forwarded-Proto \$proxy_scheme;
             proxy_pass ${1};
         }
+        location /api/v2/ {
+            ${HTTP_BASIC}
+            proxy_set_header Authorization "";
+            proxy_set_header X-Forwarded-Host \$host:\$server_port;
+            proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto \$proxy_scheme;
+            proxy_pass ${1};
+        }
 EOF
 
 echo "${_CONFIG_SECTION}"


### PR DESCRIPTION
This works locally, but @WadeBarnes can you confirm there is nothing else required for open shift before this is merged?

This PR also adds a couple small adjustments:

- modifies the settings.sh files to fix a Mac specific issue
- adds some extra informational metadata to the swagger doc

Adresses #558, #566