### PR TITLE
#603 - Integrate Zap Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
+SonarQube Results:
+
 [![Bugs](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook&metric=bugs&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook) [![Vulnerabilities](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook&metric=vulnerabilities&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook) [![Code smells](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook&metric=code_smells&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook) [![Coverage](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook&metric=coverage&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook) [![Duplication](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook&metric=duplicated_lines_density&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook) [![Lines of code](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook&metric=lines&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook) 
+
+Zap Results:
+
+[![Bugs](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook-Zap&metric=bugs&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook-Zap) [![Vulnerabilities](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook-Zap&metric=vulnerabilities&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook-Zap) [![Code smells](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/api/badges/measure?key=TheOrgBook-Zap&metric=code_smells&template=FLAT)](https://sonarqube-devex-von-tools.pathfinder.gov.bc.ca/dashboard?id=TheOrgBook-Zap)
 
 # TheOrgBook
 

--- a/SonarQube-Jenkinsfile
+++ b/SonarQube-Jenkinsfile
@@ -2,6 +2,9 @@
 // SonarQube Scanner Settings
 // ------------------------------------------------------------------------------------------------
 
+// The name of the SonarQube route.  Used to dynamically get the URL for SonarQube.
+def SONAR_ROUTE_NAME = 'sonarqube'
+
 // The name of your SonarQube project
 def SONAR_PROJECT_NAME = 'TheOrgBook'
 
@@ -17,6 +20,33 @@ def SONAR_PROJECT_BASE_DIR = '../'
 // This is relative to the project base directory.
 def SONAR_SOURCES = './'
 // ================================================================================================
+
+@NonCPS
+String getUrlForRoute(String routeName, String projectNameSpace = '') {
+
+  def nameSpaceFlag = ''
+  if(projectNameSpace?.trim()) {
+    nameSpaceFlag = "-n ${projectNameSpace}"
+  }
+  
+  def url = sh (
+    script: "oc get routes ${nameSpaceFlag} -o wide --no-headers | awk \'/${routeName}/{ print match(\$0,/edge/) ?  \"https://\"\$2 : \"http://\"\$2 }\'",
+    returnStdout: true
+  ).trim()
+
+  return url
+}
+
+@NonCPS
+String getSonarQubePwd() {
+
+  sonarQubePwd = sh (
+    script: 'oc env dc/sonarqube --list | awk  -F  "=" \'/SONARQUBE_ADMINPW/{print $2}\'',
+    returnStdout: true
+  ).trim()
+
+  return sonarQubePwd
+}
 
 // The jenkins-python3nodejs template has been purpose built for supporting SonarQube scanning.
 podTemplate(
@@ -48,16 +78,8 @@ podTemplate(
     stage('SonarQube Analysis') {
       echo "Performing static SonarQube code analysis ..."
 
-      SONARQUBE_PWD = sh (
-        script: 'oc env dc/sonarqube --list | awk  -F  "=" \'/SONARQUBE_ADMINPW/{print $2}\'',
-        returnStdout: true
-      ).trim()
-
-      SONARQUBE_URL = sh (
-        script: 'oc get routes -o wide --no-headers | awk \'/sonarqube/{ print match($0,/edge/) ?  "https://"$2 : "http://"$2 }\'',
-        returnStdout: true
-      ).trim()
-
+      SONARQUBE_URL = getUrlForRoute(SONAR_ROUTE_NAME).trim()
+      SONARQUBE_PWD = getSonarQubePwd().trim()
       echo "URL: ${SONARQUBE_URL}"
       echo "PWD: ${SONARQUBE_PWD}"
 

--- a/Zap-Jenkinsfile
+++ b/Zap-Jenkinsfile
@@ -1,0 +1,220 @@
+// ================================================================================================
+// SonarQube Scanner Settings
+// ------------------------------------------------------------------------------------------------
+
+// The name of the SonarQube route.  Used to dynamically get the URL for SonarQube.
+def SONAR_ROUTE_NAME = 'sonarqube'
+
+// The name of your SonarQube project
+def SONAR_PROJECT_NAME = 'TheOrgBook-Zap'
+
+// The project key of your SonarQube project
+def SONAR_PROJECT_KEY = 'TheOrgBook-Zap'
+
+// The base directory of your project.
+// This is relative to the location of the `sonar-runner` directory within your project.
+// More accurately this is relative to the Gradle build script(s) that manage the SonarQube Scanning
+def SONAR_PROJECT_BASE_DIR = '../'
+
+// The source code directory you want to scan.
+// This is relative to the project base directory.
+def SONAR_SOURCES = './zap/wrk'
+// ================================================================================================
+
+// ================================================================================================
+// ZAP Scanner Settings
+// ------------------------------------------------------------------------------------------------
+
+// The name of the target route.  This will be used to dynamically get the URL.
+def TARGET_ROUTE = 'angular-on-nginx'
+
+// The namespace in which the target route can be found.  This will be used to dynamically get the URL.
+def TARGET_PROJECT_NAMESPACE = 'devex-von-dev'
+
+// The path to the API.
+def API_PATH='/api'
+
+// The API format; either openapi or soap
+def API_FORMAT = 'openapi'
+
+// The name  of the ZAP report
+def ZAP_REPORT_NAME = "zap-report.xml"
+
+// The location of the ZAP reports
+def ZAP_REPORT_PATH = "/zap/wrk/${ZAP_REPORT_NAME}"
+
+// The name of the "stash" containing the ZAP report
+def ZAP_REPORT_STASH = "zap-report"
+// ================================================================================================
+
+@NonCPS
+String getUrlForRoute(String routeName, String projectNameSpace = '') {
+
+  def nameSpaceFlag = ''
+  if(projectNameSpace?.trim()) {
+    nameSpaceFlag = "-n ${projectNameSpace}"
+  }
+  
+  def url = sh (
+    script: "oc get routes ${nameSpaceFlag} -o wide --no-headers | awk \'/${routeName}/{ print match(\$0,/edge/) ?  \"https://\"\$2 : \"http://\"\$2 }\'",
+    returnStdout: true
+  ).trim()
+
+  return url
+}
+
+@NonCPS
+String getSonarQubePwd() {
+
+  sonarQubePwd = sh (
+    script: 'oc env dc/sonarqube --list | awk  -F  "=" \'/SONARQUBE_ADMINPW/{print $2}\'',
+    returnStdout: true
+  ).trim()
+
+  return sonarQubePwd
+}
+
+// The jenkins-slave-zap image has been purpose built for supporting ZAP scanning.
+podTemplate(
+  label: 'owasp-zap', 
+  name: 'owasp-zap', 
+  serviceAccount: 'jenkins', 
+  cloud: 'openshift', 
+  containers: [
+    containerTemplate(
+      name: 'jnlp',
+      image: '172.50.0.2:5000/openshift/jenkins-slave-zap',
+      resourceRequestCpu: '500m',
+      resourceLimitCpu: '1000m',
+      resourceRequestMemory: '3Gi',
+      resourceLimitMemory: '4Gi',
+      workingDir: '/home/jenkins',
+      command: '',
+      args: '${computer.jnlpmac} ${computer.name}'
+    )
+  ]
+){
+  node('owasp-zap') {
+    stage('ZAP Security Scan') {
+
+      // Dynamicaly determine the target URL for the ZAP scan ...
+      def TARGET_URL = getUrlForRoute(TARGET_ROUTE, TARGET_PROJECT_NAMESPACE).trim()
+      def API_TARGET_URL="${TARGET_URL}${API_PATH}/?format=${API_FORMAT}"
+
+      echo "Target URL: ${TARGET_URL}"
+      echo "API Target URL: ${API_TARGET_URL}"
+
+      dir('zap') {
+
+        // The ZAP scripts are installed on the root of the jenkins-slave-zap image.
+        // When running ZAP from there the reports will be created in /zap/wrk/ by default.
+        // ZAP has problems with creating the reports directly in the Jenkins
+        // working directory, so they have to be copied over after the fact.
+        def retVal = sh (
+          returnStatus: true,
+          script: "/zap/zap-baseline.py -x ${ZAP_REPORT_NAME} -t ${TARGET_URL}"
+          // Other scanner options ...
+          // zap-api-scan errors out
+          // script: "/zap/zap-api-scan.py -x ${ZAP_REPORT_NAME} -t ${API_TARGET_URL} -f ${API_FORMAT}"
+          // script: "/zap/zap-full-scan.py -x ${ZAP_REPORT_NAME} -t ${TARGET_URL}"
+        )
+        echo "Return value is: ${retVal}"
+
+        // Copy the ZAP report into the Jenkins working directory so the Jenkins tools can access it.
+        sh (
+          returnStdout: true,
+          script: "mkdir -p ./wrk/ && cp ${ZAP_REPORT_PATH} ./wrk/"
+        )
+      }
+
+      // Stash the ZAP report for publishing in a different stage (which will run on a different pod).
+      echo "Stash the report for the publishing stage ..."
+      stash name: "${ZAP_REPORT_STASH}", includes: "zap/wrk/*.xml"
+    }
+  }
+}
+
+// The jenkins-python3nodejs template has been purpose built for supporting SonarQube scanning.
+podTemplate(
+  label: 'jenkins-python3nodejs',
+  name: 'jenkins-python3nodejs',
+  serviceAccount: 'jenkins',
+  cloud: 'openshift',
+  containers: [
+    containerTemplate(
+      name: 'jnlp',
+      image: '172.50.0.2:5000/openshift/jenkins-slave-python3nodejs',
+      resourceRequestCpu: '1000m',
+      resourceLimitCpu: '2000m',
+      resourceRequestMemory: '2Gi',
+      resourceLimitMemory: '4Gi',
+      workingDir: '/tmp',
+      command: '',
+      args: '${computer.jnlpmac} ${computer.name}'
+    )
+  ]
+){
+  node('jenkins-python3nodejs') {
+
+    stage('Publish ZAP Report to SonarQube') {
+
+      // Do a sparse checkout of the sonar-runner folder since it is the only
+      // part of the project we need to publish the ZAP report to SonarQube.
+      // We're not scanning our source code here ...
+      //
+      // For this to work the Jenkins Administrator may have to approve the following methods;
+      // - method hudson.plugins.git.GitSCM getBranches
+      // - method hudson.plugins.git.GitSCM getUserRemoteConfigs
+      // - method hudson.plugins.git.GitSCMBackwardCompatibility getExtensions
+      // - staticMethod org.codehaus.groovy.runtime.DefaultGroovyMethods plus java.util.Collection java.lang.Object
+      echo "Checking out the sonar-runner folder ..."
+      checkout([
+          $class: 'GitSCM',
+          branches: scm.branches,
+          extensions: scm.extensions + [
+            [$class: 'SparseCheckoutPaths',  sparseCheckoutPaths:[[path:'sonar-runner/']]]
+          ],
+          userRemoteConfigs: scm.userRemoteConfigs
+      ])
+
+      echo "Preparing the report for the publishing ..."
+      unstash name: "${ZAP_REPORT_STASH}"
+
+      SONARQUBE_URL = getUrlForRoute(SONAR_ROUTE_NAME).trim()
+      SONARQUBE_PWD = getSonarQubePwd().trim()
+      echo "URL: ${SONARQUBE_URL}"
+      echo "PWD: ${SONARQUBE_PWD}"
+
+      echo "Publishing the report ..."
+      // The `sonar-runner` MUST exist in your project and contain a Gradle environment consisting of:
+      // - Gradle wrapper script(s)
+      // - A simple `build.gradle` file that includes the SonarQube plug-in.
+      //
+      // An example can be found here:
+      // - https://github.com/BCDevOps/sonarqube
+      dir('sonar-runner') {
+        // ======================================================================================================
+        // Set your SonarQube scanner properties at this level, not at the Gradle Build level.
+        // The only thing that should be defined at the Gradle Build level is a minimal set of generic defaults.
+        //
+        // For more information on available properties visit:
+        // - https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+Gradle
+        // ======================================================================================================
+        sh (
+          // 'sonar.zaproxy.reportPath' must be set to the absolute path of the xml formatted ZAP report.
+          // Exclude the report from being scanned as an xml file.  We only care about the results of the ZAP scan.
+          returnStdout: true,
+          script: "./gradlew sonarqube --stacktrace --info \
+            -Dsonar.verbose=true \
+            -Dsonar.host.url=${SONARQUBE_URL} \
+            -Dsonar.projectName=${SONAR_PROJECT_NAME} \
+            -Dsonar.projectKey=${SONAR_PROJECT_KEY} \
+            -Dsonar.projectBaseDir=${SONAR_PROJECT_BASE_DIR} \
+            -Dsonar.sources=${SONAR_SOURCES} \
+            -Dsonar.zaproxy.reportPath=${WORKSPACE}${ZAP_REPORT_PATH} \
+            -Dsonar.exclusions=**/*.xml"
+        )
+      }
+    }
+  }
+}

--- a/Zap-Jenkinsfile.bc-tob.pipeline.param
+++ b/Zap-Jenkinsfile.bc-tob.pipeline.param
@@ -1,0 +1,11 @@
+#=========================================================
+# OpenShift Jenkins pipeline template parameters for:
+# Jenkinsfile: ./Zap-Jenkinsfile
+# Template File: https://raw.githubusercontent.com/BCDevOps/openshift-tools/master/provisioning/pipeline/resources/pipeline-build.json
+#=========================================================
+NAME=zap
+# GITHUB_WEBHOOK_SECRET=[a-zA-Z0-9]{40}
+SOURCE_REPOSITORY_URL=https://github.com/bcgov/TheOrgBook.git
+SOURCE_REPOSITORY_REF=master
+CONTEXT_DIR=
+JENKINSFILE_PATH=Zap-Jenkinsfile

--- a/tob-web/Jenkinsfile
+++ b/tob-web/Jenkinsfile
@@ -1,4 +1,4 @@
-// Edit your app's name below 
+// Edit your app's name below
 def APP_NAME = 'angular-app'
 
 // Edit your environment TAG names below
@@ -7,7 +7,7 @@ def TAG_NAMES = ['dev', 'test', 'prod']
 // You shouldn't have to edit these if you're following the conventions
 def BUILD_CONFIG = APP_NAME + '-build'
 
-//EDIT LINE BELOW (Change `IMAGESTREAM_NAME` so it matches the name of your *output*/deployable image stream.) 
+//EDIT LINE BELOW (Change `IMAGESTREAM_NAME` so it matches the name of your *output*/deployable image stream.)
 def IMAGESTREAM_NAME = 'angular-on-nginx'
 
 // you'll need to change this to point to your application component's folder within your repository
@@ -21,6 +21,12 @@ def RUNTIME_BUILD_CONFIG = 'nginx-runtime'
 // EDIT LINE BELOW (Add a reference to the CHAINED_BUILD_CONFIG)
 def CHAINED_BUILD_CONFIG = 'angular-on-nginx-build'
 
+// The name of your deployment configuration; used to verify the deployment
+def DEPLOYMENT_CONFIG_NAME= 'angular-on-nginx'
+
+// The namespace of you dev deployment environment.
+def DEV_NAME_SPACE = 'devex-von-dev'
+
 @NonCPS
 boolean triggerBuild(String contextDirectory) {
   // Determine if code has changed within the source context directory.
@@ -30,12 +36,10 @@ boolean triggerBuild(String contextDirectory) {
     def entries = changeLogSets[i].items
     for (int j = 0; j < entries.length; j++) {
       def entry = entries[j]
-      //echo "${entry.commitId} by ${entry.author} on ${new Date(entry.timestamp)}: ${entry.msg}"
       def files = new ArrayList(entry.affectedFiles)
       for (int k = 0; k < files.size(); k++) {
         def file = files[k]
         def filePath = file.path
-        //echo ">> ${file.path}"
         if (filePath.contains(contextDirectory)) {
           filesChangeCnt = 1
           k = files.size()
@@ -44,7 +48,7 @@ boolean triggerBuild(String contextDirectory) {
       }
     }
   }
-  
+
   if ( filesChangeCnt < 1 ) {
     echo('The changes do not require a build.')
     return false
@@ -52,37 +56,105 @@ boolean triggerBuild(String contextDirectory) {
   else {
     echo('The changes require a build.')
     return true
-  } 
+  }
+}
+
+// Get an image's hash tag
+String getImageTagHash(String imageName, String tag = "") {
+
+  if(!tag?.trim()) {
+    tag = "latest"
+  }
+
+  def istag = openshift.raw("get istag ${imageName}:${tag} -o template --template='{{.image.dockerImageReference}}'")
+  return istag.out.tokenize('@')[1].trim()
 }
 
 node {
-  if( triggerBuild(CONTEXT_DIRECTORY) ) {   
-    stage('build ' + BUILD_CONFIG) {
-      
-      // Build the application artifacts
-      echo "Building: " + BUILD_CONFIG
-      openshiftBuild bldCfg: BUILD_CONFIG, showBuildLogs: 'true'
+  if( triggerBuild(CONTEXT_DIRECTORY) ) {
 
-      // Build the runtime image, if you are not using an off the shelf one.
-      openshiftBuild bldCfg: RUNTIME_BUILD_CONFIG, showBuildLogs: 'true'
+    stage("Build ${BUILD_CONFIG}") {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
 
-      // the CHAINED_BUILD_CONFIG should be triggered when the above build completes, but it doesn't seem to be, so we trigger it explicitly.
-      openshiftBuild bldCfg: CHAINED_BUILD_CONFIG, showBuildLogs: 'true'
-      
-      // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
-      // Tag the images for deployment based on the image's hash
-      IMAGE_HASH = sh (
-        script: """oc get istag ${IMAGESTREAM_NAME}:latest -o template --template=\"{{.image.dockerImageReference}}\"|awk -F \":\" \'{print \$3}\'""",
-        returnStdout: true).trim()
-      echo ">> IMAGE_HASH: ${IMAGE_HASH}"
+            echo "Building the application artifacts ..."
+            def build = openshift.selector("bc", "${BUILD_CONFIG}")
+            build.startBuild().logs("-f")
+          }
+        }
+      }
     }
-    
-    stage('deploy-' + TAG_NAMES[0]) {
-      openshiftTag destStream: IMAGESTREAM_NAME, verbose: 'true', destTag: TAG_NAMES[0], srcStream: IMAGESTREAM_NAME, srcTag: "${IMAGE_HASH}"
+
+    // Build the runtime image, if you are not using an off the shelf one.
+    stage("Build ${RUNTIME_BUILD_CONFIG}") {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
+
+            echo "Building the ${RUNTIME_BUILD_CONFIG} image ..."
+            def build = openshift.selector("bc", "${RUNTIME_BUILD_CONFIG}")
+            build.startBuild().logs("-f")
+          }
+        }
+      }
+    }
+
+    stage("Build ${IMAGESTREAM_NAME}") {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
+
+            echo "Building the ${IMAGESTREAM_NAME} image ..."
+            def build = openshift.selector("bc", "${CHAINED_BUILD_CONFIG}")
+            build.startBuild().logs("-f")
+          }
+        }
+      }
+    }
+
+    stage("Deploy " + TAG_NAMES[0]) {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
+
+            echo "Tagging ${IMAGESTREAM_NAME} for deployment to " + TAG_NAMES[0] + " ..."
+
+            // Don't tag with BUILD_ID so the pruner can do it's job; it won't delete tagged images.
+            // Tag the images for deployment based on the image's hash
+            def IMAGE_HASH = getImageTagHash("${IMAGESTREAM_NAME}")
+            echo "IMAGE_HASH: ${IMAGE_HASH}"
+            openshift.tag("${IMAGESTREAM_NAME}@${IMAGE_HASH}", "${IMAGESTREAM_NAME}:" + TAG_NAMES[0])
+          }
+
+          openshift.withProject("${DEV_NAME_SPACE}") {
+              def dc = openshift.selector('dc', "${DEPLOYMENT_CONFIG_NAME}")
+              // Wait for the deployment to complete.
+              // This will wait until the desired replicas are all available
+              dc.rollout().status()
+          }
+
+          echo "Deployment Complete."
+        }
+      }
+    }
+
+    stage('Trigger ZAP Scan') {
+      script {
+        openshift.withCluster() {
+          openshift.withProject() {
+
+            echo "Triggering an asynchronous ZAP Scan ..."
+            def zapScan = openshift.selector("bc", "zap-pipeline")
+            zapScan.startBuild()
+          }
+        }
+      }
     }
   }
   else {
     stage('No Changes') {
+      echo "No changes ..."
       currentBuild.result = 'SUCCESS'
     }
   }


### PR DESCRIPTION
- Add a stand-alone Zap Scanning pipeline which preforms a baseline scan on the application once deployed to DEV.
  - Performs scan and then publishes the results in SonarQube-Jenkinsfile
- Wire the Zap Scan into the tob-web pipeline
  - The pipeline now waits for the deployment to complete and then triggers the Zap Scanning pipeline to perform an acrimonious scan.
  - Also migrated the tob-web pipeline over to using the OpenShift Client Jenkins Plugin syntax.
- Add Zap quality badges to the ReadMe which link to the live reports in SonarQube.