### PR TITLE
Restrict rxjs to version 6.3.x (6.4 requires a newer typescript version)

### DIFF
--- a/tob-web/package.json
+++ b/tob-web/package.json
@@ -38,7 +38,7 @@
     "font-awesome": "^4.7.0",
     "localize-router": "https://github.com/cywolf/localize-router/releases/download/v2.0.0-RC.2/localize-router-2.0.0-RC.2.tgz",
     "localize-router-http-loader": "~1.0.2",
-    "rxjs": "^6.0.0",
+    "rxjs": "~6.3.0",
     "rxjs-compat": "^6.0.0",
     "zone.js": "^0.8.26"
   },


### PR DESCRIPTION
Signed-off-by: Andrew Whitehead <cywolf@gmail.com>