### PR TITLE
Use internal URL by default for index verification.

### DIFF
--- a/tob-api/api_indy/management/commands/verify_credential_index.py
+++ b/tob-api/api_indy/management/commands/verify_credential_index.py
@@ -19,7 +19,7 @@ from tob_api.rocketchat_hooks import log_error, log_warning, log_info
 
 from asgiref.sync import async_to_sync
 
-API_BASE_URL = os.environ.get('APPLICATION_URL', 'http://localhost:8080')
+API_BASE_URL = os.environ.get('API_BASE_URL', 'http://localhost:8080')
 API_PATH = os.environ.get('API_PATH', '/api/v2')
 API_URL = "{}{}".format(API_BASE_URL, API_PATH)
 


### PR DESCRIPTION
Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>