### PR TITLE
Hide credentials in the timeline if they have no effective date

### DIFF
--- a/tob-web/src/app/cred/form.component.ts
+++ b/tob-web/src/app/cred/form.component.ts
@@ -98,8 +98,8 @@ export class CredFormComponent implements OnInit, OnDestroy, AfterViewInit {
     if(credset) {
       if(credset.first_effective_date && credset.first_effective_date < range.start) {
         if (credset.first_effective_date < '0100-01-01') {
-          range.start = '1970-01-01T00:00:00-00:00';
-        } else {
+            //range.start = '';
+          } else {
           range.start = credset.first_effective_date;
         }
       }
@@ -111,7 +111,14 @@ export class CredFormComponent implements OnInit, OnDestroy, AfterViewInit {
         slots: []
       };
       for(let cred of credset.credentials) {
-        row.slots.push(this._formatter.getCredentialSlot(cred));
+        if(!cred.effective_date || cred.effective_date < "0100-01-01") {
+          // skip for timeline
+        } else {
+          if(cred.effective_date && cred.effective_date < range.start) {
+            range.start = cred.effective_date;
+          }
+          row.slots.push(this._formatter.getCredentialSlot(cred));
+        }
       }
       rows.push(row);
       this._timelineRange = range;

--- a/tob-web/src/app/cred/timeline.component.ts
+++ b/tob-web/src/app/cred/timeline.component.ts
@@ -67,7 +67,7 @@ export class CredSetTimelineComponent implements OnInit, OnDestroy {
         if(! credset.credentials) continue;
         if(credset.first_effective_date && credset.first_effective_date < range.start) {
           if (credset.first_effective_date < '0100-01-01') {
-            range.start = '1970-01-01T00:00:00-00:00';
+            //range.start = '';
           } else {
             range.start = credset.first_effective_date;
           }
@@ -80,7 +80,14 @@ export class CredSetTimelineComponent implements OnInit, OnDestroy {
           slots: []
         };
         for(let cred of credset.credentials) {
-          row.slots.push(this._formatter.getCredentialSlot(cred));
+          if(!cred.effective_date || cred.effective_date < "0100-01-01") {
+            // skip for timeline
+          } else {
+            if(cred.effective_date && cred.effective_date < range.start) {
+              range.start = cred.effective_date;
+            }
+            row.slots.push(this._formatter.getCredentialSlot(cred));
+          }
         }
         rows.push(row);
       }


### PR DESCRIPTION
In the timeline, hide credentials if:
- they have no effective date
- they have an invalid effective date
