### PR TITLE
Fixed topic attributes not displaying correctly on OrgBook UI

### DIFF
--- a/tob-api/api_v2/models/Topic.py
+++ b/tob-api/api_v2/models/Topic.py
@@ -1,12 +1,10 @@
-from django.db import models
-
 from django.core.exceptions import ValidationError
+from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
-from .Auditable import Auditable
 
 from .Address import Address
 from .Attribute import Attribute
+from .Auditable import Auditable
 from .Name import Name
 
 
@@ -54,7 +52,7 @@ class Topic(Auditable):
     def get_active_attributes(self):
         creds = self.get_active_credential_ids()
         if creds:
-            return Attribute.objects.filter(credential_id__in=creds, credential__credential_type__description='Registration')
+            return Attribute.objects.filter(credential_id__in=creds)
         return []
 
     def get_active_names(self):
@@ -100,4 +98,3 @@ class Topic(Auditable):
         return self.related_from.filter(
             to_rels__credential__latest=True,
             to_rels__credential__revoked=False)
-

--- a/tob-api/api_v2/serializers/search.py
+++ b/tob-api/api_v2/serializers/search.py
@@ -1,45 +1,36 @@
 # TODO: migrate most of these serializers to a UI specific serializer module
 
+import logging
 from collections import OrderedDict
 from datetime import datetime, timedelta
-import logging
 
-from django.db.models.manager import Manager
-
-from rest_framework.serializers import ListSerializer, ModelSerializer, SerializerMethodField
-from rest_framework.utils.serializer_helpers import ReturnDict
-from drf_haystack.serializers import (
-    FacetFieldSerializer,
-    HaystackFacetSerializer,
-    HaystackSerializerMixin,
-)
-
-from api_v2.serializers.rest import (
-    AddressSerializer,
-    AttributeSerializer,
-    NameSerializer,
-    TopicSerializer,
-    TopicRelationshipSerializer,
-    CredentialSerializer,
-    CredentialSetSerializer,
-    CredentialTypeSerializer,
-    IssuerSerializer,
-    CredentialAddressSerializer,
-    CredentialAttributeSerializer,
-    CredentialNameSerializer,
-    CredentialTopicExtSerializer,
-    CredentialNamedTopicSerializer,
-)
-
+from api_v2 import utils
 from api_v2.models.Address import Address
 from api_v2.models.Attribute import Attribute
 from api_v2.models.Credential import Credential
 from api_v2.models.CredentialType import CredentialType
 from api_v2.models.Issuer import Issuer
 from api_v2.models.Name import Name
-from api_v2 import utils
-
 from api_v2.search_indexes import CredentialIndex
+from api_v2.serializers.rest import (AddressSerializer, AttributeSerializer,
+                                     CredentialAddressSerializer,
+                                     CredentialAttributeSerializer,
+                                     CredentialNamedTopicSerializer,
+                                     CredentialNameSerializer,
+                                     CredentialSerializer,
+                                     CredentialSetSerializer,
+                                     CredentialTopicExtSerializer,
+                                     CredentialTypeSerializer,
+                                     IssuerSerializer, NameSerializer,
+                                     TopicRelationshipSerializer,
+                                     TopicSerializer)
+from django.db.models.manager import Manager
+from drf_haystack.serializers import (FacetFieldSerializer,
+                                      HaystackFacetSerializer,
+                                      HaystackSerializerMixin)
+from rest_framework.serializers import (ListSerializer, ModelSerializer,
+                                        SerializerMethodField)
+from rest_framework.utils.serializer_helpers import ReturnDict
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +167,6 @@ class CustomTopicSerializer(TopicSerializer):
     def get_attributes(self, obj):
         attributes = Attribute.objects.filter(
             credential__topic=obj,
-            credential__credential_type__description='Registration',
             credential__latest=True,
             credential__revoked=False,
         ).order_by('credential__inactive')


### PR DESCRIPTION
Removed filter that would cause no data to be returned when retrieving Topic attributes for schemas with description different than "Registration".