### PR TITLE
Add packaging to requirements.txt, since it is required by drf_yasg.

### DIFF
--- a/tob-api/requirements.txt
+++ b/tob-api/requirements.txt
@@ -15,6 +15,7 @@ whitenoise>=4.1.0,<4.2
 # Documentation
 # django_rest_swagger>=2.1.2,<3
 drf-yasg>=1.10.2,<2
+packaging>=19.0,<20
 flex>=6.13.2,<7
 swagger-spec-validator>=2.4.0,<3
 


### PR DESCRIPTION
Workaround until drf_yasg 1.16.2 is released.