### PR TITLE
Enable agent-defined claim labels

### DIFF
--- a/tob-web/src/app/general-data.service.ts
+++ b/tob-web/src/app/general-data.service.ts
@@ -390,11 +390,8 @@ export class GeneralDataService {
       map(values => {
         let lang = this.language;
         let ret = undefined;
-        if (values && lang in values) {
-          let labels = values[lang];
-          if (labels && catType in labels) {
-            ret = labels[catType][catValue];
-          }
+        if (values && catType in values) {
+          ret = values[catType][lang];
         }
         return ret;
       }),

--- a/tob-web/src/app/general-data.service.ts
+++ b/tob-web/src/app/general-data.service.ts
@@ -1,31 +1,26 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { BehaviorSubject, concat, of, from, Observable, Observer, Subscription } from 'rxjs';
-import { catchError, map, mergeMap, switchMap, shareReplay } from 'rxjs/operators';
+import { BehaviorSubject, from, Observable, Observer, of, Subscription } from 'rxjs';
 import { _throw } from 'rxjs/observable/throw';
+import { catchError, map, mergeMap, shareReplay } from 'rxjs/operators';
+
 import { environment } from '../environments/environment';
 import { Fetch, Filter, Model } from './data-types';
 
-
 @Injectable()
 export class GeneralDataService {
-
   public apiUrl = environment.API_URL;
   private _quickLoaded = false;
-  private _orgData : {[key: string]: any} = {};
-  private _recordCounts : {[key: string]: number} = {};
+  private _orgData: { [key: string]: any } = {};
+  private _recordCounts: { [key: string]: number } = {};
   private _currentResultSubj = new BehaviorSubject<Fetch.BaseResult<any>>(null);
   private _loaderSub: Subscription = null;
-  private _defaultTopicType = 'registration';
+  private _defaultTopicType = "registration";
   private _showDebugMsg = false;
-  private _credTypeLang =  {};
+  private _credTypeLang = {};
 
-  constructor(
-    private _http: HttpClient,
-    private _translate: TranslateService,
-  ) {
-  }
+  constructor(private _http: HttpClient, private _translate: TranslateService) {}
 
   get language() {
     return this._translate.currentLang;
@@ -35,15 +30,15 @@ export class GeneralDataService {
     return this._showDebugMsg;
   }
 
-  getRequestUrl(path: string) : string {
-    if(typeof path === 'string' && path.match(/^(\/\/|\w+:\/\/)\w/)) {
+  getRequestUrl(path: string): string {
+    if (typeof path === "string" && path.match(/^(\/\/|\w+:\/\/)\w/)) {
       // absolute URL
       return path;
     }
     let root = (<any>window).testApiUrl || this.apiUrl;
 
-    if(root) {
-      if(! root.endsWith('/')) root += '/';
+    if (root) {
+      if (!root.endsWith("/")) root += "/";
       return root + path;
     }
   }
@@ -52,121 +47,129 @@ export class GeneralDataService {
     return this._defaultTopicType;
   }
 
-  loadJson(url, params?: HttpParams) : Observable<Object> {
-    return this._http.get(url, {params})
-      .pipe(catchError(error => {
+  loadJson(url, params?: HttpParams): Observable<Object> {
+    return this._http.get(url, { params }).pipe(
+      catchError(error => {
         console.error("JSON load error", error);
         return _throw(error);
-      }));
+      })
+    );
   }
 
-  postJson(url, payload, params?: HttpParams) : Observable<Object> {
-    let headers = {'Content-Type': 'application/json'};
-    return this._http.post(url, JSON.stringify(payload), {headers, params})
-      .pipe(catchError(error => {
+  postJson(url, payload, params?: HttpParams): Observable<Object> {
+    let headers = { "Content-Type": "application/json" };
+    return this._http.post(url, JSON.stringify(payload), { headers, params }).pipe(
+      catchError(error => {
         console.error("JSON load error", error);
         return _throw(error);
-      }));
+      })
+    );
   }
 
-  postParams(url, params: {[key: string]: string}|HttpParams) : Observable<Object> {
+  postParams(url, params: { [key: string]: string } | HttpParams): Observable<Object> {
     let body = this.makeHttpParams(params);
-    return this._http.post(url, body)
-      .pipe(catchError(error => {
+    return this._http.post(url, body).pipe(
+      catchError(error => {
         console.error("JSON load error", error);
         return _throw(error);
-      }));
+      })
+    );
   }
 
-  loadFromApi(path: string, params?: HttpParams) : Observable<Object> {
+  loadFromApi(path: string, params?: HttpParams): Observable<Object> {
     let url = this.getRequestUrl(path);
-    if(url) {
+    if (url) {
       return this.loadJson(url, params);
     }
   }
 
   quickLoad(force?) {
     return new Promise((resolve, reject) => {
-      if(this._quickLoaded && !force) {
+      if (this._quickLoaded && !force) {
         resolve(1);
         return;
       }
-      let baseurl = this.getRequestUrl('');
+      let baseurl = this.getRequestUrl("");
       //console.log('base url: ' + baseurl);
-      if(! baseurl) {
+      if (!baseurl) {
         reject("Base URL not defined");
         return;
       }
-      let req = this._http.get(baseurl + 'quickload')
-        .pipe(catchError(error => {
+      let req = this._http.get(baseurl + "quickload").pipe(
+        catchError(error => {
           console.error(error);
           return _throw(error);
-        }));
-      req.subscribe((data: any) => {
-        if(data.counts) {
-          for (let k in data.counts) {
-            this._recordCounts[k] = parseInt(data.counts[k]);
+        })
+      );
+      req.subscribe(
+        (data: any) => {
+          if (data.counts) {
+            for (let k in data.counts) {
+              this._recordCounts[k] = parseInt(data.counts[k]);
+            }
           }
-        }
-        if(data.credential_counts) {
-          for (let k in data.credential_counts) {
-            this._recordCounts[k] = parseInt(data.credential_counts[k]);
+          if (data.credential_counts) {
+            for (let k in data.credential_counts) {
+              this._recordCounts[k] = parseInt(data.credential_counts[k]);
+            }
           }
-        }
-        if(data.records) {
-          for (let k in data.records) {
-            this._orgData[k] = data.records[k];
+          if (data.records) {
+            for (let k in data.records) {
+              this._orgData[k] = data.records[k];
+            }
           }
+          if (data.demo) {
+            this._showDebugMsg = true;
+          }
+          this._quickLoaded = true;
+          resolve(1);
+        },
+        err => {
+          reject(err);
         }
-        if(data.demo) {
-          this._showDebugMsg = true;
-        }
-        this._quickLoaded = true;
-        resolve(1);
-      }, err => {
-        reject(err);
-      });
+      );
     });
   }
 
-  getRecordCount (type) {
+  getRecordCount(type) {
     return this._recordCounts[type] || 0;
   }
 
-  autocomplete (term) : Observable<Object> {
-    if(term === '' || typeof(term) !== 'string') {
+  autocomplete(term): Observable<Object> {
+    if (term === "" || typeof term !== "string") {
       return from([]);
     }
-    let params = new HttpParams().set('q', term);
-    return this.loadFromApi('search/autocomplete', params)
-      .pipe(map(response => {
+    let params = new HttpParams().set("q", term);
+    return this.loadFromApi("search/autocomplete", params).pipe(
+      map(response => {
         let ret = [];
-        for(let row of response['results']) {
+        for (let row of response["results"]) {
           let found = null;
-          for(let name of row.names) {
-            if(~ name.text.toLowerCase().indexOf(term.toLowerCase())) {
+          for (let name of row.names) {
+            if (~name.text.toLowerCase().indexOf(term.toLowerCase())) {
               found = name.text;
               break;
-            } else if(found === null) {
+            } else if (found === null) {
               found = name.text;
             }
           }
-          if(found !== null) {
-            ret.push({id: row.id, term: found});
+          if (found !== null) {
+            ret.push({ id: row.id, term: found });
           }
         }
         return ret;
-      }));
+      })
+    );
   }
 
-  makeHttpParams(query?: { [key: string ]: string } | HttpParams) {
+  makeHttpParams(query?: { [key: string]: string } | HttpParams) {
     let httpParams: HttpParams;
-    if(query instanceof HttpParams) {
+    if (query instanceof HttpParams) {
       httpParams = query;
     } else {
       httpParams = new HttpParams();
-      if(query) {
-        for(let k in query) {
+      if (query) {
+        for (let k in query) {
           httpParams = httpParams.set(k, query[k]);
         }
       }
@@ -174,36 +177,32 @@ export class GeneralDataService {
     return httpParams;
   }
 
-  fixRecordId (id: number | string) {
-    if(typeof id === 'number')
-      id = ''+id;
+  fixRecordId(id: number | string) {
+    if (typeof id === "number") id = "" + id;
     return id;
   }
 
-  loadRecord <T>(
-      fetch: Fetch.DataLoader<T>,
-      id: string | number,
-      params?: { [key: string ]: any }) {
-    if(! params) params = {};
-    let path = params.path || fetch.request.getRecordPath(
-      this.fixRecordId(id), this.fixRecordId(params.childId), params.extPath);
+  loadRecord<T>(fetch: Fetch.DataLoader<T>, id: string | number, params?: { [key: string]: any }) {
+    if (!params) params = {};
+    let path =
+      params.path ||
+      fetch.request.getRecordPath(this.fixRecordId(id), this.fixRecordId(params.childId), params.extPath);
     return this.loadData(fetch, path, params);
   }
 
-  loadList <T>(fetch: Fetch.ListLoader<T>, params?: { [key: string ]: any }) {
-    if(! params) params = {};
+  loadList<T>(fetch: Fetch.ListLoader<T>, params?: { [key: string]: any }) {
+    if (!params) params = {};
     let path = params.path || fetch.request.getListPath(params.parentId, params.extPath);
     return this.loadData(fetch, path, params);
   }
 
-  loadAll <M extends Model.BaseModel>(
-      ctor: Model.ModelCtor<M>): Promise<M[]> {
+  loadAll<M extends Model.BaseModel>(ctor: Model.ModelCtor<M>): Promise<M[]> {
     let loader = new Fetch.ModelListLoader<M>(ctor);
     let allRows: M[] = [];
     return new Promise((resolve, fail) => {
       loader.stream.subscribe(result => {
         // FIXME - implement pagination
-        if(result.loaded) {
+        if (result.loaded) {
           allRows = allRows.concat(result.data);
           resolve(allRows);
         }
@@ -212,66 +211,68 @@ export class GeneralDataService {
     });
   }
 
-  loadData <T, R extends Fetch.BaseResult<T>>(fetch: Fetch.BaseLoader<T,R>, path: string, params?: { [key: string ]: any }) {
-    if(! params) params = {};
-    if(! path)
+  loadData<T, R extends Fetch.BaseResult<T>>(
+    fetch: Fetch.BaseLoader<T, R>,
+    path: string,
+    params?: { [key: string]: any }
+  ) {
+    if (!params) params = {};
+    if (!path)
       // fetch.loadNotFound
       fetch.loadError("Undefined resource path");
     else {
       let httpParams = this.makeHttpParams(params.query);
       let url = this.getRequestUrl(path);
       //console.log("loadData(url)", url);
-      if(params.primary) {
-        if(this._loaderSub)
-          this._loaderSub.unsubscribe();
-        this._loaderSub = fetch.stream.subscribe((result) => {
+      if (params.primary) {
+        if (this._loaderSub) this._loaderSub.unsubscribe();
+        this._loaderSub = fetch.stream.subscribe(result => {
           this.setCurrentResult(result);
         });
       }
-      fetch.loadFrom(this.loadJson(url, httpParams), {url: url});
+      fetch.loadFrom(this.loadJson(url, httpParams), { url: url });
     }
   }
 
   public loadFacetOptions(data) {
-    let fields = data.info && data.info.facets && data.info.facets.fields || {};
+    let fields = (data.info && data.info.facets && data.info.facets.fields) || {};
     //console.log(fields);
     let options = {
       credential_type_id: [],
       issuer_id: [],
-      'category:entity_type': [],
+      "category:entity_type": []
     };
     //console.log(options);
-    if(fields) {
-      for(let optname in fields) {
-        for(let optitem of fields[optname]) {
-          if(! optitem.count)
+    if (fields) {
+      for (let optname in fields) {
+        for (let optitem of fields[optname]) {
+          if (!optitem.count)
             // skip facets with no results
             continue;
           let optidx = optname;
-          let optval: Filter.Option = {label: optitem.text, value: optitem.value, count: optitem.count};
-          if(optname == 'category') {
-            let optparts = optitem.value.split('::', 2);
-            if(optparts.length == 2) {
-              optidx = optname + ':' + optparts[0];
+          let optval: Filter.Option = { label: optitem.text, value: optitem.value, count: optitem.count };
+          if (optname == "category") {
+            let optparts = optitem.value.split("::", 2);
+            if (optparts.length == 2) {
+              optidx = optname + ":" + optparts[0];
               let lblkey = `category.${optparts[0]}.${optparts[1]}`;
               let label = this._translate.instant(lblkey);
-              if(label === lblkey || label === `??${lblkey}??`)
-                label = optparts[1];
+              if (label === lblkey || label === `??${lblkey}??`) label = optparts[1];
               optval = {
                 label,
                 value: optparts[1],
-                count: optitem.count,
+                count: optitem.count
               };
             }
           }
-          if(optidx in options) {
+          if (optidx in options) {
             options[optidx].push(optval);
           }
         }
       }
     }
-    for(let name in options) {
-      options[name].sort((a,b) => a.label.localeCompare(b.label));
+    for (let name in options) {
+      options[name].sort((a, b) => a.label.localeCompare(b.label));
     }
     return options;
   }
@@ -284,17 +285,18 @@ export class GeneralDataService {
     this._currentResultSubj.next(result);
   }
 
-  deleteRecord (mod: string, id: string) {
+  deleteRecord(mod: string, id: string) {
     return new Promise(resolve => {
       let baseurl = this.getRequestUrl(`${mod}/${id}/delete`);
-      let req = this._http.post(baseurl, {params: {id}})
-        .pipe(catchError(error => {
+      let req = this._http.post(baseurl, { params: { id } }).pipe(
+        catchError(error => {
           console.error(error);
           resolve(null);
           return _throw(error);
-        }));
+        })
+      );
       req.subscribe(data => {
-        console.log('delete result', data);
+        console.log("delete result", data);
         resolve(data);
       });
     });
@@ -304,19 +306,25 @@ export class GeneralDataService {
     return Observable.create((observer: Observer<any>) => {
       let url = this.getRequestUrl(`credentialtype/${credTypeId}/language`);
       this.loadJson(url).subscribe(
-        data => { observer.next(data); observer.complete(); },
-        err  => { observer.error(err); }
+        data => {
+          observer.next(data);
+          observer.complete();
+        },
+        err => {
+          observer.error(err);
+        }
       );
     });
   }
 
   getCredentialTypeLanguage(id) {
-    if(! id) {
+    if (!id) {
       return of(null);
     }
-    if(! this._credTypeLang[id]) {
-      this._credTypeLang[id] = //concat(
-        this.loadCredentialTypeLanguage(id).pipe(shareReplay(1)); /*,
+    if (!this._credTypeLang[id]) {
+      this._credTypeLang[id] = this.loadCredentialTypeLanguage(id).pipe(
+        shareReplay(1)
+      ); /*,
         this._translate.onLangChange.pipe(
           switchMap((event) => null, (outer, inner) => { console.log(outer, inner); return outer; })
         )*/
@@ -326,14 +334,18 @@ export class GeneralDataService {
   }
 
   getCredentialTypeLanguageKey(credTypeId, key) {
-    return this.getCredentialTypeLanguage(credTypeId).pipe(map(data => (data && data[key])));
+    return this.getCredentialTypeLanguage(credTypeId).pipe(
+      map(data => {
+        return data && data[key];
+      })
+    );
   }
 
   preloadCredentialTypeLanguage(...ids) {
     return new Promise(resolve => {
       let result = Promise.resolve(null);
-      if(ids) {
-        for(let i = 0; i < ids.length; i ++) {
+      if (ids) {
+        for (let i = 0; i < ids.length; i++) {
           result = result.then(this.getCredentialTypeLanguage(ids[i]));
         }
       }
@@ -342,53 +354,53 @@ export class GeneralDataService {
   }
 
   translateClaimDescription(credTypeId, claimName, defVal?) {
-    let credLang = this.getCredentialTypeLanguageKey(credTypeId, 'claim_descriptions');
-    return credLang.then(values => {
-      let lang = this.language;
-      let ret = undefined;
-      if(lang in values) {
-        ret = values[lang][claimName];
-      }
-      if(ret === undefined)
-        ret = defVal;
-      return ret;
-    });
+    let credLang = this.getCredentialTypeLanguageKey(credTypeId, "claim_descriptions");
+    return credLang.pipe(
+      map(values => {
+        let lang = this.language;
+        let ret = undefined;
+        if (values && claimName in values) {
+          ret = values[claimName][lang];
+        }
+        if (ret === undefined) ret = defVal;
+        return ret;
+      })
+    );
   }
 
   translateClaimLabel(credTypeId, claimName, defVal?) {
-    let credLang = this.getCredentialTypeLanguageKey(credTypeId, 'claim_labels');
-    return credLang.then(values => {
-      let lang = this.language;
-      let ret = undefined;
-      if(lang in values) {
-        ret = values[lang][claimName];
-      }
-      if(ret === undefined)
-        ret = defVal;
-      return ret;
-    });
+    let credLang = this.getCredentialTypeLanguageKey(credTypeId, "claim_labels");
+    return credLang.pipe(
+      map(values => {
+        let lang = this.language;
+        let ret = undefined;
+        if (values && claimName in values) {
+          ret = values[claimName][lang];
+        }
+        if (ret === undefined) ret = defVal;
+        return ret;
+      })
+    );
   }
 
   translateCategoryLabel(credTypeId, catType, catValue) {
-    let credLang = this.getCredentialTypeLanguageKey(credTypeId, 'category_labels');
+    let credLang = this.getCredentialTypeLanguageKey(credTypeId, "category_labels");
     let lbl = `category.${catType}.${catValue}`;
     return credLang.pipe(
       map(values => {
         let lang = this.language;
         let ret = undefined;
-        if(values && lang in values) {
+        if (values && lang in values) {
           let labels = values[lang];
-          if(labels && catType in labels) {
+          if (labels && catType in labels) {
             ret = labels[catType][catValue];
           }
         }
         return ret;
       }),
       mergeMap(val => {
-        if(val === undefined)
-          return this._translate.stream(lbl).pipe(map(
-            lbl => (! lbl || lbl.substring(0, 2) == '??') ? catValue : lbl
-          ));
+        if (val === undefined)
+          return this._translate.stream(lbl).pipe(map(lbl => (!lbl || lbl.substring(0, 2) == "??" ? catValue : lbl)));
         return of(val);
       })
     );

--- a/tob-web/src/app/util/attribute-list.component.ts
+++ b/tob-web/src/app/util/attribute-list.component.ts
@@ -1,56 +1,51 @@
 import { Component, Input } from '@angular/core';
-import { Model } from '../data-types';
 import { TranslateService } from '@ngx-translate/core';
 
+import { Model } from '../data-types';
+import { GeneralDataService } from '../general-data.service';
+
 @Component({
-  selector: 'attribute-list',
-  templateUrl: '../../themes/_active/util/attribute-list.component.html',
-  styleUrls: [
-    '../../themes/_active/cred/cred.scss',
-  ]
+  selector: "attribute-list",
+  templateUrl: "../../themes/_active/util/attribute-list.component.html",
+  styleUrls: ["../../themes/_active/cred/cred.scss"]
 })
 export class AttributeListComponent {
-
   @Input() byType: string[];
-  @Input() style: string = 'table';
+  @Input() style: string = "table";
 
   protected _rows: Model.Attribute[] = [];
 
-  constructor(
-    private _translate: TranslateService,
-  ) {}
+  constructor(private _dataService: GeneralDataService, private _translate: TranslateService) {}
 
   @Input() set records(input: Model.Attribute[]) {
-    if(! input) {
+    if (!input) {
       this._rows = [];
       return;
     }
     let attrMap = {};
     let attrLabels = {};
-    for(let attr of input) {
+    for (let attr of input) {
       attrMap[attr.type] = attr;
       attrLabels[attr.typeLabel] = attr.type;
     }
     let labels = Object.keys(attrLabels);
-    if(labels.length) {
+    if (labels.length) {
       this._translate.stream(labels).subscribe(trLabels => {
         let rows = [];
         let typeLabels = {};
-        for(let labelKey in trLabels) {
+        for (let labelKey in trLabels) {
           let label = trLabels[labelKey];
-          if(label && label.substring(0, 2) != '??')
-            typeLabels[attrLabels[labelKey]] = label;
+          if (label && label.substring(0, 2) != "??") typeLabels[attrLabels[labelKey]] = label;
         }
-        if(this.byType) {
-          for(let type of this.byType) {
-            if(type in attrMap)
-              rows.push({label: typeLabels[type] || type, attr: attrMap[type]});
+        if (this.byType) {
+          for (let type of this.byType) {
+            if (type in attrMap) rows.push({ label: typeLabels[type] || type, attr: attrMap[type] });
           }
         } else {
-          for(let type in attrMap) {
-            rows.push({label: typeLabels[type] || type, attr: attrMap[type]});
+          for (let type in attrMap) {
+            rows.push({ label: typeLabels[type] || type, attr: attrMap[type] });
           }
-          rows.sort((a,b) => a.label.localeCompare(b.label));
+          rows.sort((a, b) => a.label.localeCompare(b.label));
         }
         this._rows = rows;
       });
@@ -59,5 +54,9 @@ export class AttributeListComponent {
 
   get rows() {
     return this._rows;
+  }
+
+  getAttributeLabel(row: any) {
+    return this._dataService.translateClaimLabel(row.attr.credential_type_id, row.attr.type, row.label);
   }
 }

--- a/tob-web/src/themes/default/util/attribute-list.component.html
+++ b/tob-web/src/themes/default/util/attribute-list.component.html
@@ -2,7 +2,7 @@
   <table class="table attribute-table">
     <tr class="attribute-row" *ngFor="let row of rows">
       <td>
-        <label class="control-label attribute-type">{{row.label}}</label>
+        <label class="control-label attribute-type">{{ getAttributeLabel(row) | async }}</label>
       </td>
       <td>
         <attribute-view [record]="row.attr"></attribute-view>


### PR DESCRIPTION
Apart from a bit of noise introduced by the VSCode typescript formatter (I can go through and revert those changes, if deemed necessary), the changes include adding a function to `attribute-list.component` to pull the labels and display them, if available.

