### PR TITLE
Replace all dashes with underscores in bash script

### DIFF
--- a/tob-web/openshift/templates/nginx-runtime/s2i/bin/run
+++ b/tob-web/openshift/templates/nginx-runtime/s2i/bin/run
@@ -104,7 +104,7 @@ getApiUrl (){
   #   Results in API_URL=https://dev-demo-api.orgbook.gov.bc.ca/api/v2/
   # ================================================================================
   if [ ! -z "${API_SERVICE_NAME}" ]; then
-    _SERVICE_NAME="$(tr '[:lower:]' '[:upper:]' <<< ${API_SERVICE_NAME/-/_})"
+    _SERVICE_NAME="$(tr '[:lower:]' '[:upper:]' <<< ${API_SERVICE_NAME//-/_})"
     _SERVICE_HOST_NAME=${_SERVICE_NAME}_SERVICE_HOST
     _SERVICE_PORT_NAME=${_SERVICE_NAME}_SERVICE_PORT
 


### PR DESCRIPTION
Fixes string replacement for names with multiple slashes, e.g. "API-SERVICE-NAME"
See https://stackoverflow.com/questions/5928156/replace-one-character-with-another-in-bash

Signed-off-by: Alejandro Sanchez <emailforasr@gmail.com>